### PR TITLE
Update PKGBUILD to include the GitHub URL for this fork

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,17 +1,18 @@
 # Contributor: Sean Pringle <sean.pringle@gmail.com>
+# Contributor: Dave Davenport
 
 pkgname=simpleswitcher-git
 pkgver=20120625
 pkgrel=1
 pkgdesc="simple EWMH window switcher"
 arch=('i686' 'x86_64')
-url="http://github.com/seanpringle/simpleswitcher"
+url="http://github.com/DaveDavenport/simpleswitcher"
 license=('MIT')
 depends=('libx11' 'libxft' 'freetype2')
 makedepends=('git')
 provides=('simpleswitcher')
 
-_gitroot="git://github.com/seanpringle/simpleswitcher.git"
+_gitroot="git://github.com/DaveDavenport/simpleswitcher.git"
 _gitname="simpleswitcher"
 
 build() {


### PR DESCRIPTION
I noticed that the Arch Linux PKGBUILD for this thing is rather outdated, so I updated the URL to https://github.com/DaveDavenport/simpleswitcher (and added you as a contributor; I have no idea what your email is so you could edit that in later I suppose).

I guess you don't really want this if you have the intention of submitting these changes back to seanpringle/simpleswitcher, but I don't see any pull requests pertaining to the i3 stuff over there.

BTW, as an i3 user I find this thing really helpful, thanks!
