### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install: normal install-man
 	install -Dm 755 simpleswitcher $(BINDIR)/simpleswitcher
 
 install-man:
-	install -Dm 644 simpleswitcher.1 $(MANDIR)
+	install -Dm 644 simpleswitcher.1 $(MANDIR)/simpleswitcher.1
 	gzip -f $(MANDIR)/simpleswitcher.1
 
 clean:


### PR DESCRIPTION
Fixing `install`'s behavior if `$(MANDIR)` doesn't exist _(eg. in [Arch](https://archlinux.org/)'s AUR PKGBUILDs)_.
