### PR TITLE
Hide error if `clang` is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ CFLAGS+=-D__QC_MODE__
 endif
 
 
-CLANG=$(shell which clang)
+CLANG=$(shell which clang 2>/dev/null)
 
 ifneq (${CLANG},${EMPTY})
     $(info Using clang compiler: ${CLANG})


### PR DESCRIPTION
Hiding the ugly `which: no clang in (/usr/local/bin:/usr/bin:…)`
