### PR TITLE
moving older emulators to end of list

### DIFF
--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -9,7 +9,7 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in $TERMINAL x-terminal-emulator termite urxvt rxvt st terminator terminology qterminal Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal mate-terminal lxterminal konsole alacritty; do
+for terminal in $TERMINAL x-terminal-emulator termite urxvt rxvt st terminator terminology qterminal Eterm aterm gnome-terminal roxterm xfce4-terminal mate-terminal lxterminal konsole alacritty uxterm xterm; do
     if command -v $terminal > /dev/null 2>&1; then
         exec $terminal "$@"
     fi


### PR DESCRIPTION
I have gnome-terminal installed, but it won't get run by this script because it finds uxterm and xterm first. Moving those to the end fixes this, and should fix the problem for other users--assuming xterm is installed by default in most distros.