### PR TITLE
Don't expose cairo or glib in public includes

### DIFF
--- a/include/helper.h
+++ b/include/helper.h
@@ -27,9 +27,10 @@
 
 #ifndef ROFI_HELPER_H
 #define ROFI_HELPER_H
-#include <cairo.h>
 #include "rofi-types.h"
-G_BEGIN_DECLS
+#include <stddef.h>
+#include <sys/types.h>
+ROFI_BEGIN_DECLS
 
 /**
  * @defgroup HELPERS Helpers
@@ -336,5 +337,5 @@ void parse_ranges ( char *input, rofi_range_pair **list, unsigned int *length );
  * @param filter
  */
 void rofi_output_formatted_line ( const char *format, const char *string, int selected_line, const char *filter );
-G_END_DECLS
+ROFI_END_DECLS
 #endif // ROFI_HELPER_H

--- a/include/mode-private.h
+++ b/include/mode-private.h
@@ -27,11 +27,13 @@
 
 #ifndef ROFI_MODE_PRIVATE_H
 #define ROFI_MODE_PRIVATE_H
-#include <gmodule.h>
-G_BEGIN_DECLS
+#include "rofi-types.h"
+ROFI_BEGIN_DECLS
 
 /** ABI version to check if loaded plugin is compatible. */
 #define ABI_VERSION    0x00000006
+
+typedef struct rofi_mode Mode;
 
 /**
  * @param data Pointer to #Mode object.
@@ -196,5 +198,5 @@ struct rofi_mode
     /** Module */
     GModule    *module;
 };
-G_END_DECLS
+ROFI_END_DECLS
 #endif // ROFI_MODE_PRIVATE_H

--- a/include/mode.h
+++ b/include/mode.h
@@ -27,9 +27,8 @@
 
 #ifndef ROFI_MODE_H
 #define ROFI_MODE_H
-#include <cairo.h>
 #include "rofi-types.h"
-G_BEGIN_DECLS
+ROFI_BEGIN_DECLS
 /**
  * @defgroup MODE Mode
  *
@@ -42,23 +41,6 @@ G_BEGIN_DECLS
  * Access should be done via mode_* functions.
  */
 typedef struct rofi_mode Mode;
-
-/**
- * Enum used to sum the possible states of ROFI.
- */
-typedef enum
-{
-    /** Exit. */
-    MODE_EXIT       = 1000,
-    /** Skip to the next cycle-able dialog. */
-    NEXT_DIALOG     = 1001,
-    /** Reload current DIALOG */
-    RELOAD_DIALOG   = 1002,
-    /** Previous dialog */
-    PREVIOUS_DIALOG = 1003,
-    /** Reloads the dialog and unset user input */
-    RESET_DIALOG    = 1004,
-} ModeMode;
 
 /**
  * State returned by the rofi window.
@@ -236,5 +218,5 @@ char * mode_preprocess_input ( Mode *mode, const char *input );
  */
 char *mode_get_message ( const Mode *mode );
 /*@}*/
-G_END_DECLS
+ROFI_END_DECLS
 #endif

--- a/include/rofi-icon-fetcher.h
+++ b/include/rofi-icon-fetcher.h
@@ -1,9 +1,10 @@
 #ifndef ROFI_ICON_FETCHER_H
 #define ROFI_ICON_FETCHER_H
 
-#include <glib.h>
+#include "rofi-types.h"
 #include <stdint.h>
-#include <cairo.h>
+
+ROFI_BEGIN_DECLS
 
 /**
  * @defgroup ICONFETCHER IconFetcher
@@ -46,4 +47,6 @@ uint32_t rofi_icon_fetcher_query ( const char *name, const int size );
 cairo_surface_t * rofi_icon_fetcher_get ( const uint32_t uid );
 
 /* @} */
+
+ROFI_END_DECLS
 #endif // ROFI_ICON_FETCHER_H

--- a/include/rofi-types.h
+++ b/include/rofi-types.h
@@ -1,8 +1,27 @@
 #ifndef INCLUDE_ROFI_TYPES_H
 #define INCLUDE_ROFI_TYPES_H
 
-#include <glib.h>
-G_BEGIN_DECLS
+#ifdef  __cplusplus
+# define ROFI_BEGIN_DECLS  extern "C" {
+# define ROFI_END_DECLS    }
+#else
+# define ROFI_BEGIN_DECLS
+# define ROFI_END_DECLS
+#endif
+
+ROFI_BEGIN_DECLS
+
+typedef char gchar;
+typedef int gint;
+typedef gint gboolean;
+typedef long glong;
+typedef signed long gssize;
+typedef void* gpointer;
+typedef struct _GList GList;
+typedef struct _GModule GModule;
+typedef struct _GRegex GRegex;
+typedef struct _GThreadPool GThreadPool;
+typedef struct _cairo_surface cairo_surface_t;
 
 /**
  * Type of property
@@ -42,6 +61,23 @@ typedef enum
  * It is important this is kept in sync.
  */
 extern const char * const PropertyTypeName[P_NUM_TYPES];
+
+/**
+ * Enum used to sum the possible states of ROFI.
+ */
+typedef enum
+{
+    /** Exit. */
+    MODE_EXIT       = 1000,
+    /** Skip to the next cycle-able dialog. */
+    NEXT_DIALOG     = 1001,
+    /** Reload current DIALOG */
+    RELOAD_DIALOG   = 1002,
+    /** Previous dialog */
+    PREVIOUS_DIALOG = 1003,
+    /** Reloads the dialog and unset user input */
+    RESET_DIALOG    = 1004,
+} ModeMode;
 
 /** Style of text highlight */
 typedef enum
@@ -246,5 +282,5 @@ typedef struct _thread_state
 
 extern GThreadPool *tpool;
 
-G_END_DECLS
+ROFI_END_DECLS
 #endif // INCLUDE_ROFI_TYPES_H


### PR DESCRIPTION
This change removes the requirement for modules
to depend on cairo and glib to build.  This change
fixes errors related to missing <glib.h> and <cairo.h>
for projects that do not wish to use these libraries.