### PR TITLE
Updated list of terminals

### DIFF
--- a/doc/rofi-sensible-terminal.1
+++ b/doc/rofi-sensible-terminal.1
@@ -77,7 +77,40 @@ rxvt
 .sp -1
 .IP \(bu 2.3
 .\}
+st
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 terminator
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+terminology
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+qterminal
 .RE
 .sp
 .RS 4
@@ -100,6 +133,17 @@ Eterm
 .IP \(bu 2.3
 .\}
 aterm
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+uxterm
 .RE
 .sp
 .RS 4
@@ -144,6 +188,39 @@ roxterm
 .IP \(bu 2.3
 .\}
 xfce4\-terminal
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+mate\-terminal
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+lxterminal
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+konsole
 .RE
 .sp
 Please don\(cqt complain about the order: If the user has any preference, she will have $TERMINAL set or modified her rofi configuration file\&.


### PR DESCRIPTION
As pointed out in #850, the list of terminals in the rofi-sensible-terminal man page was out of date. 
The list is now up to date with the "rofi-sensible-terminal" script list. 