### PR TITLE
Port over dmenu flag '-selected-row'

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -195,6 +195,11 @@ static void run_switcher ( ModeMode mode )
     if ( rofi_view_get_active () == NULL ) {
         g_main_loop_quit ( main_loop  );
     }
+
+    unsigned int start_select = 0;
+    if ( find_arg_uint ( "-selected-row", &start_select ) ) {
+        rofi_view_set_selected_line ( state, start_select );
+    }
 }
 void process_result ( RofiViewState *state )
 {


### PR DESCRIPTION
In #38 people have resorted to xdotool hacks to skip to the second row on startup. Upon experimentation this seemed buggy for really fast alt tabs. This patch allows us to set the selected row using the `-selected-row` flag, just like in dmenu. Docs are incomplete so far, as I don't know where to document this. As I am also very unfamiliar with this code I have no clue if this addition is in a logical place.

For now I named this argument the same as the dmenu equivalent that I found in the docs. I don't know if this is a good idea in terms of confusion.

Feedback is welcome.