### PR TITLE
Add support for additional field on script entries `meta`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /doc/*.html
 /doc/*.doxy
 /gitconfig.h
+test/output.txt
 
 # I want to ignore log files
 *.log

--- a/include/dialogs/dmenuscriptshared.h
+++ b/include/dialogs/dmenuscriptshared.h
@@ -8,6 +8,8 @@ typedef struct {
     char     *icon_name;
     /** Async icon fetch handler. */
     uint32_t icon_fetch_uid;
+    /** Hidden meta keywords. */
+    char     *meta;
 } DmenuScriptEntry;
 /**
  * @param sw Unused

--- a/source/dialogs/dmenu.c
+++ b/source/dialogs/dmenu.c
@@ -122,6 +122,7 @@ static void read_add ( DmenuModePrivateData * pd, char *data, gsize len )
     // Init.
     pd->cmd_list[pd->cmd_list_length].icon_fetch_uid = 0;
     pd->cmd_list[pd->cmd_list_length].icon_name      = NULL;
+    pd->cmd_list[pd->cmd_list_length].meta           = NULL;
     char *end = strchr(data, '\0');
     if ( end != NULL ) {
         data_len = end-data;
@@ -309,6 +310,7 @@ static void dmenu_mode_free ( Mode *sw )
             if ( pd->cmd_list[i].entry ) {
                 g_free ( pd->cmd_list[i].entry );
                 g_free ( pd->cmd_list[i].icon_name );
+                g_free ( pd->cmd_list[i].meta );
             }
         }
         g_free ( pd->cmd_list );

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -7,6 +7,7 @@ tests=(
     run_dmenu_custom_test
     run_run_test
     run_script_test
+    run_script_meta_test
     run_issue_256
     run_issue_275
     run_dmenu_empty

--- a/test/run_script_meta_test.sh
+++ b/test/run_script_meta_test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+SP=$(readlink -f "$0")
+DIR=$(dirname "$SP")
+echo "$DIR/test_script.sh"
+# wait till it is up, run rofi with error message
+sleep 1;
+rofi -modi "custom:$DIR/test_script.sh" -show custom &
+RPID=$!
+
+# send enter.
+sleep 5;
+xdotool key 'z'
+sleep 0.4
+xdotool key Return
+
+#  Get result, kill xvfb
+wait ${RPID}
+RETV=$?
+OUTPUT=$( tr '\n' ' ' < output.txt )
+echo ${OUTPUT}
+if [ "${OUTPUT}" != 'mies ' ]
+then
+    exit 1
+fi
+exit ${RETV}

--- a/test/test_script.sh
+++ b/test/test_script.sh
@@ -4,7 +4,7 @@ if [ -z "$1" ]
 then
     echo "aap"
     echo "noot"
-    echo "mies"
+    echo -ne "mies\0meta\x1fzoom\n"
 else
     echo $1 > output.txt
 fi


### PR DESCRIPTION
## Purpose

For some script mode usages and displays, the content is given additional information to help in finding the desired output (like with the `rofimoji` and `kaomoji rofi` user scripts).  Since there is already a spec and support for adding icons, it seems sensible to add in a "meta" field for entries to provide matchable text but not include it in the primary entry field.

## Implementation

Following the same logic as used for parsing the `icon` field on an entry, an additional `meta` field is added and parsed out.  This field is then used along with the primary entry content when doing token matching.  This is similar in behavior to how the `drun` dialog works with matching things like `keyword` or `category` for more contextual searching.