### PR TITLE
man: Fix typo

### DIFF
--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -921,7 +921,7 @@ Show the run dialog:
 
     rofi -modi run -show run
 
-Show the the run dialog, and allow switching to Desktop File run dialog (drun):
+Show the run dialog, and allow switching to Desktop File run dialog (drun):
 
     rofi -modi run,drun -show run
 


### PR DESCRIPTION
Removed a duplicate word "the" on rofi.1.markdown.