### PR TITLE
Remove gnome-terminal from rofi-sensible-terminal

### DIFF
--- a/doc/rofi-sensible-terminal.1
+++ b/doc/rofi-sensible-terminal.1
@@ -121,17 +121,6 @@ xterm
 .sp -1
 .IP \(bu 2.3
 .\}
-gnome\-terminal
-.RE
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.sp -1
-.IP \(bu 2.3
-.\}
 roxterm
 .RE
 .sp

--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -9,7 +9,7 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal mate-terminal lxterminal konsole alacritty kitty; do
+for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm roxterm xfce4-terminal mate-terminal lxterminal konsole alacritty kitty; do
     if command -v $terminal > /dev/null 2>&1; then
         exec $terminal "$@"
     fi


### PR DESCRIPTION
As mentioned in #1003, gnome-terminal does not work. [Also noted there](https://github.com/davatorium/rofi/issues/1003#issuecomment-518390269):
> if gnome-terminal is no longer compatible it should be taken out of rofi-sensible-terminal.