### PR TITLE
add missing -eh (line height) option to man pages

### DIFF
--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -362,6 +362,11 @@ To show sidebar, use:
 
     rofi -show run -sidebar-mode -lines 0
 
+`-eh` *number*
+
+Set row height (in chars)
+Default: *1*
+
 `-auto-select`
 
 When one entry is left, automatically select it.


### PR DESCRIPTION
`rofi -h` output includes `-eh` option but `man rofi` doesnt.
adds missing `-eh` option to man pages.

related to #1072