### PR TITLE
fix xetc to config_path

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -926,7 +926,7 @@ int main ( int argc, char *argv[] )
         else {
             g_free ( config_path_new );
             config_path_new = NULL;
-            if ( g_file_test ( xetc, G_FILE_TEST_IS_REGULAR ) ) {
+            if ( g_file_test ( config_path, G_FILE_TEST_IS_REGULAR ) ) {
                 config_parse_xresource_options_file ( config_path );
                 old_config_format = TRUE;
             }


### PR DESCRIPTION
There was a minor mistake that caused build to fail. I hope this fix is correct. It seemed trivial, but you never know..
