### PR TITLE
mention rofi-script in rofi man page

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,4 +1,4 @@
 Update manpage using ronn [https://github.com/rtomayko/ronn]
 
-    ronn --roff --pipe rofi-manpage.markdown > rofi.1
+    ronn --roff --pipe rofi.1.markdown > rofi.1
 

--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -1691,7 +1691,7 @@ first.
 
 .SH SEE ALSO
 .PP
-rofi\-sensible\-terminal(1), dmenu(1), rofi\-theme(5), rofi\-theme\-selector(1)
+rofi\-sensible\-terminal(1), dmenu(1), rofi\-theme(5), rofi\-theme\-selector(1), rofi\-script(5)
 
 .SH AUTHOR
 .PP

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -1019,7 +1019,7 @@ first.
 
 ## SEE ALSO
 
-rofi-sensible-terminal(1), dmenu(1), rofi-theme(5), rofi-theme-selector(1)
+rofi-sensible-terminal(1), dmenu(1), rofi-theme(5), rofi-theme-selector(1), rofi-script(5)
 
 ## AUTHOR
 


### PR DESCRIPTION
Mention rofi-script in rofi man page.

NOTE: I updated the instructions on how to build the man page from markdown, I hope it was correct. However, when I built the man page, the diff was huge, almost all lines were different in some way. Perhaps some difference ronn version could cause that? Anyway, for that reason, I didn't commit the built man page but just manually picked the line that was affected by my change in the markdown file.
