### PR TITLE
add IRC and Reddit links to issue template chooser

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Rofi subreddit
+    url: https://www.reddit.com/r/qtools/
+    about: Please ask and answer questions here.
+  - name: Rofi IRC channel
+    url: irc://chat.freenode.net/rofi
+    about: Please ask and answer question in real time here.


### PR DESCRIPTION
This PR adds a link to Reddit and IRC on the GitHub issue page. The goal is to help lead people on the right platform. You can [see an example on the polybar issue page](https://github.com/polybar/polybar/issues/new/choose).