### PR TITLE
Man pages: document the bang feature

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -987,7 +987,7 @@ rofi \-show combi \-combi\-modi "window,run,ssh" \-modi combi
 .RE
 
 .PP
-Notes: The i3 window manager does not like commas in the command when specifying an exec command.
+\fBNOTE\fP: The i3 window manager does not like commas in the command when specifying an exec command.
 For that case '#' can be used as a separator.
 
 .SS History and Sorting
@@ -1599,6 +1599,17 @@ Shows a searchable list of key bindings.
 .SS script
 .PP
 Allows custom scripted Modi to be added.
+
+.SS combi
+.PP
+Combines multiple modi in one list. Specify which modi are included with the \fB\fC\-combi\-modi\fR option.
+
+.PP
+When using the combi mode, a \fI!bang\fP can be used to filter the results by modi.
+All modi that match the bang as a prefix are included.
+For example, say you have specified \fB\fC\-combi\-modi run,window,windowcd\fR\&. If your
+query begins with the bang \fB\fC!w\fR, only results from the \fB\fCwindow\fR and \fB\fCwindowcd\fR
+modi are shown, even if the rest of the input text would match results from \fB\fCrun\fR\&.
 
 .SH FAQ
 .SS The text in the window switcher is not nicely aligned.

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -568,7 +568,7 @@ To get one merge view, of `window`,`run`, and `ssh`:
 
     rofi -show combi -combi-modi "window,run,ssh" -modi combi
 
-Notes: The i3 window manager does not like commas in the command when specifying an exec command.
+**NOTE**: The i3 window manager does not like commas in the command when specifying an exec command.
 For that case '#' can be used as a separator.
 
 ### History and Sorting
@@ -945,6 +945,16 @@ Shows a searchable list of key bindings.
 ### script
 
 Allows custom scripted Modi to be added.
+
+### combi
+
+Combines multiple modi in one list. Specify which modi are included with the `-combi-modi` option.
+
+When using the combi mode, a *!bang* can be used to filter the results by modi.
+All modi that match the bang as a prefix are included.
+For example, say you have specified `-combi-modi run,window,windowcd`. If your
+query begins with the bang `!w`, only results from the `window` and `windowcd`
+modi are shown, even if the rest of the input text would match results from `run`.
 
 ## FAQ
 


### PR DESCRIPTION
There's otherwise no sign of the bang feature in the man page.

If #1124 is merged, this will need a tweak: s/query begins/query contains/