### PR TITLE
xrmoptions: add element-height alias for eh

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -724,7 +724,8 @@ rofi \-show run \-sidebar\-mode \-lines 0
 .RE
 
 .PP
-\fB\fC\-eh\fR \fInumber\fP
+\fB\fC\-eh\fR \fInumber\fP;
+\fB\fC\-element\-height\fR \fInumber\fP
 
 .PP
 Set row height (in chars)

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -397,7 +397,8 @@ To show sidebar, use:
 
     rofi -show run -sidebar-mode -lines 0
 
-`-eh` *number*
+`-eh` *number*;
+`-element-height` *number*
 
 Set row height (in chars)
 Default: *1*

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -156,6 +156,8 @@ static XrmOption xrmOptions[] = {
       "Cycle through the results list", CONFIG_DEFAULT },
     { xrm_Boolean, "sidebar-mode",              { .num   = &config.sidebar_mode                         }, NULL,
       "Enable sidebar-mode", CONFIG_DEFAULT },
+    { xrm_SNumber, "element-height",            { .snum  = &config.element_height                       }, NULL,
+      "Row height (in chars)", CONFIG_DEFAULT },
     { xrm_SNumber, "eh",                        { .snum  = &config.element_height                       }, NULL,
       "Row height (in chars)", CONFIG_DEFAULT },
     { xrm_Boolean, "auto-select",               { .num   = &config.auto_select                          }, NULL,


### PR DESCRIPTION
When looking through other people's Rofi configuration, one might
stumble upon the option `eh`.  It's hard to tell what it does at first
glance, unlike other options.  Create an alias `element-height` for `eh`
that is more understandable.  Hopefully, people start adopting this in
their config files for readability.