### PR TITLE
Support rasi config character type options

### DIFF
--- a/include/rofi-types.h
+++ b/include/rofi-types.h
@@ -15,6 +15,8 @@ typedef enum
     P_DOUBLE,
     /** String */
     P_STRING,
+    /** Character */
+    P_CHAR,
     /** Boolean */
     P_BOOLEAN,
     /** Color */
@@ -211,6 +213,8 @@ typedef union _PropertyValue
     double      f;
     /** String */
     char        *s;
+    /** Character */
+    char        c;
     /** boolean */
     gboolean    b;
     /** Color */

--- a/lexer/theme-lexer.l
+++ b/lexer/theme-lexer.l
@@ -169,6 +169,7 @@ WSO        [[:blank:]]*
 WORD       [[:alnum:]-]+
 COLOR_NAME [[:alpha:]]+
 STRING     \"{UANYN}*\"
+CHAR       \'({ASCN}|\\\\|\\\'|\\0)\'
 HEX        [[:xdigit:]]
 NUMBER     [[:digit:]]
 PNNUMBER   [-+]?[[:digit:]]+
@@ -441,6 +442,7 @@ if ( queue == NULL ){
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT,MEDIA_CONTENT>{PNNUMBER}\.{NUMBER}+ { yylval->fval = g_ascii_strtod(yytext, NULL); return T_DOUBLE;}
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT,MEDIA_CONTENT>{PNNUMBER}            { yylval->ival = (int)g_ascii_strtoll(yytext, NULL, 10); return T_INT;}
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT>{STRING}              { yytext[yyleng-1] = '\0'; yylval->sval = g_strcompress(&yytext[1]); return T_STRING;}
+<PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT>{CHAR}                { yytext[yyleng-1] = '\0'; yylval->sval = g_strcompress(&yytext[1]); return T_STRING;}
 
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT>@{WORD}               {
     yylval->sval = g_strdup(yytext+1);

--- a/lexer/theme-lexer.l
+++ b/lexer/theme-lexer.l
@@ -442,7 +442,7 @@ if ( queue == NULL ){
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT,MEDIA_CONTENT>{PNNUMBER}\.{NUMBER}+ { yylval->fval = g_ascii_strtod(yytext, NULL); return T_DOUBLE;}
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT,MEDIA_CONTENT>{PNNUMBER}            { yylval->ival = (int)g_ascii_strtoll(yytext, NULL, 10); return T_INT;}
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT>{STRING}              { yytext[yyleng-1] = '\0'; yylval->sval = g_strcompress(&yytext[1]); return T_STRING;}
-<PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT>{CHAR}                { yytext[yyleng-1] = '\0'; yylval->sval = g_strcompress(&yytext[1]); return T_STRING;}
+<PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT>{CHAR}                { yytext[yyleng-1] = '\0'; yylval->cval = g_strcompress(&yytext[1])[0]; return T_CHAR;}
 
 <PROPERTIES,PROPERTIES_ENV,PROPERTIES_VAR_DEFAULT>@{WORD}               {
     yylval->sval = g_strdup(yytext+1);

--- a/lexer/theme-lexer.l
+++ b/lexer/theme-lexer.l
@@ -411,13 +411,13 @@ if ( queue == NULL ){
     BEGIN(NAMESTR);
     return T_NAME_PREFIX;
 }
-    /* Go into parsing an section*/
+    /* Go into parsing a section. */
 <NAMESTR>"\{"                    {
     g_queue_push_head ( queue, GINT_TO_POINTER (YY_START) );
     BEGIN(SECTION);
     return T_BOPEN;
 }
-  /* Pop out of parsing an section. */
+  /* Pop out of parsing a section. */
 <SECTION>"\}"             {
     g_queue_pop_head ( queue );
     BEGIN(GPOINTER_TO_INT(g_queue_pop_head ( queue )));

--- a/lexer/theme-lexer.l
+++ b/lexer/theme-lexer.l
@@ -401,7 +401,7 @@ if ( queue == NULL ){
     BEGIN(SECTION);
     return T_BOPEN;
 }
-  /** Everythin not yet parsed is an error. */
+  /** Everything not yet parsed is an error. */
 <DEFAULTS>. {
     return T_ERROR_DEFAULTS;
 }

--- a/lexer/theme-parser.y
+++ b/lexer/theme-parser.y
@@ -138,6 +138,7 @@ static ThemeColor hwb_to_rgb ( double h, double w, double b)
 	int           ival;
 	double        fval;
     char          *sval;
+    char          cval;
     int           bval;
     WindowLocation wloc;
     ThemeColor    colorval;
@@ -160,6 +161,7 @@ static ThemeColor hwb_to_rgb ( double h, double w, double b)
 %token <ival>     T_INT                 "Integer number"
 %token <fval>     T_DOUBLE              "Floating-point number"
 %token <sval>     T_STRING              "UTF-8 encoded string"
+%token <cval>     T_CHAR                "Character"
 %token <sval>     T_PROP_NAME           "property name"
 %token <colorval> T_COLOR_NAME          "Color value by name"
 %token <sval>     T_NAME_ELEMENT        "Element name"
@@ -502,6 +504,10 @@ t_property_element
 |   T_STRING {
         $$ = rofi_theme_property_create ( P_STRING );
         $$->value.s = $1;
+    }
+|   T_CHAR {
+        $$ = rofi_theme_property_create ( P_CHAR );
+        $$->value.c = $1;
     }
 |   T_LINK {
         $$ = rofi_theme_property_create ( P_LINK );

--- a/source/rofi-types.c
+++ b/source/rofi-types.c
@@ -10,6 +10,8 @@ const char * const PropertyTypeName[P_NUM_TYPES] = {
     "Double",
     /** String */
     "String",
+    /** Character */
+    "Character",
     /** Boolean */
     "Boolean",
     /** Color */

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -482,8 +482,7 @@ static gboolean __config_parser_set_property ( XrmOption *option, const Property
             *error = g_strdup_printf ( "Option: %s needs to be set with a string not a %s.", option->name, PropertyTypeName[p->type] );
             return TRUE;
         }
-        gchar value = *( p->value.s );
-        *( option->value.charc ) = value;
+        *( option->value.charc ) = *( p->value.s );
         option->source  = CONFIG_FILE_THEME;
     }
     else {

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -482,13 +482,7 @@ static gboolean __config_parser_set_property ( XrmOption *option, const Property
             *error = g_strdup_printf ( "Option: %s needs to be set with a string not a %s.", option->name, PropertyTypeName[p->type] );
             return TRUE;
         }
-
         gchar value = *( p->value.s );
-        if ( ( option )->mem != NULL ) {
-            g_free ( option->mem );
-            option->mem = NULL;
-        }
-
         *( option->value.charc ) = value;
         option->source  = CONFIG_FILE_THEME;
     }

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -422,7 +422,7 @@ void config_parse_cmd_options ( void )
 
 static gboolean __config_parser_set_property ( XrmOption *option, const Property *p, char **error  )
 {
-    if ( option->type == xrm_String  ) {
+    if ( option->type == xrm_String ) {
         if ( p->type != P_STRING && p->type != P_LIST ) {
             *error = g_strdup_printf ( "Option: %s needs to be set with a string not a %s.", option->name, PropertyTypeName[p->type] );
             return TRUE;

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -478,11 +478,11 @@ static gboolean __config_parser_set_property ( XrmOption *option, const Property
         option->source         = CONFIG_FILE_THEME;
     }
     else if ( option->type == xrm_Char ) {
-        if ( p->type != P_STRING ) {
-            *error = g_strdup_printf ( "Option: %s needs to be set with a string not a %s.", option->name, PropertyTypeName[p->type] );
+        if ( p->type != P_CHAR ) {
+            *error = g_strdup_printf ( "Option: %s needs to be set with a character not a %s.", option->name, PropertyTypeName[p->type] );
             return TRUE;
         }
-        *( option->value.charc ) = *( p->value.s );
+        *( option->value.charc ) = ( p->value.c );
         option->source  = CONFIG_FILE_THEME;
     }
     else {

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -477,6 +477,21 @@ static gboolean __config_parser_set_property ( XrmOption *option, const Property
         *( option->value.num ) = ( p->value.b );
         option->source         = CONFIG_FILE_THEME;
     }
+    else if ( option->type == xrm_Char ) {
+        if ( p->type != P_STRING ) {
+            *error = g_strdup_printf ( "Option: %s needs to be set with a string not a %s.", option->name, PropertyTypeName[p->type] );
+            return TRUE;
+        }
+
+        gchar value = *( p->value.s );
+        if ( ( option )->mem != NULL ) {
+            g_free ( option->mem );
+            option->mem = NULL;
+        }
+
+        *( option->value.charc ) = value;
+        option->source  = CONFIG_FILE_THEME;
+    }
     else {
         // TODO add type
         *error = g_strdup_printf ( "Option: %s is not of a supported type: %s.", option->name, PropertyTypeName[p->type] );


### PR DESCRIPTION
When trying to set `matching-negate-character` in a rasi config file,
the following warning shows

> Option: matching-negate-char is not of a supported type: String.

This is because character types are not yet handled.  Handle them from
the lexer all the way to xrm options.  The format shall be single quotes
containing a single ASCII character (except newline) or certain escaped
character sequences, namely

- `\'`
- `\0`
- `\\`
