### PR TITLE
Again final workaround for #303

### DIFF
--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -404,30 +404,6 @@ static void textbox_free ( widget *wid )
     g_slice_free ( textbox, tb );
 }
 
-/* FIXME: workaround for cairo bug, when subpixel rendering failed with some cairo clip paths */
-static void draw_pango_layout (cairo_t * cr, PangoLayout * layout, int x, int y)
-{
-        cairo_surface_t * txt_surf;
-        cairo_t * txt_cr;
-
-        txt_surf = cairo_recording_surface_create (CAIRO_CONTENT_COLOR_ALPHA, NULL);
-        txt_cr = cairo_create (txt_surf);
-
-        cairo_set_source (txt_cr, cairo_get_source (cr));
-        pango_cairo_show_layout (txt_cr, layout);
-        cairo_destroy (txt_cr);
-        {
-                cairo_pattern_t * pat = cairo_get_source (cr);
-                cairo_pattern_reference (pat);
-
-                cairo_set_source_surface (cr, txt_surf, x, y);
-                cairo_paint (cr);
-
-                cairo_set_source (cr, pat);
-        }
-        cairo_surface_destroy (txt_surf);
-}
-
 static void textbox_draw ( widget *wid, cairo_t *draw )
 {
     if ( wid == NULL ) {
@@ -471,7 +447,10 @@ static void textbox_draw ( widget *wid, cairo_t *draw )
     // Set ARGB
     // We need to set over, otherwise subpixel hinting wont work.
     cairo_move_to ( draw, x, top );
-    draw_pango_layout (draw, tb->layout, x, top);
+    cairo_save ( draw );
+    cairo_reset_clip ( draw );
+    pango_cairo_show_layout ( draw, tb->layout );
+    cairo_restore ( draw );
 
     // draw the cursor
     rofi_theme_get_color ( WIDGET ( tb ), "text-color", draw );


### PR DESCRIPTION
Previous fix  using intermediate image was ok only for light on dark color schemes. With dark on light it added new issue - subpixel antialiasing was mixed with greyscale in ratio, depending on text/background brightness ratio.