### PR TITLE
fix(doc): replace misleading reference to ~/.ssh/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Drun mode features:
 
 ![SSH Launcher](https://davatorium.github.io/rofi/images/rofi/ssh-dialog.png)
 
-Quickly `ssh` into remote machines. Parses `~/.ssh/config` to find hosts.
+Quickly `ssh` into remote machines. Parses `~/.ssh/known_hosts` to find hosts.
 
 ## Script mode
 


### PR DESCRIPTION
The list of hosts in ssh mode is extracted from ~/.ssh/known_hosts according to man page, but the README inaccurately references ~/.ssh/config instead.
