### PR TITLE
Follow Type=Link standard desktop entries with drun

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -125,6 +125,8 @@ Settings config = {
     .drun_show_actions         = FALSE,
     /** Desktop format display */
     .drun_display_format       = "{name} [<span weight='light' size='small'><i>({generic})</i></span>]",
+    /** Desktop Link launch command */
+    .drun_url_launcher         = "xdg-open",
 
     /** Window fields to match in window mode*/
     .window_match_fields       = "all",

--- a/config/config.c
+++ b/config/config.c
@@ -116,14 +116,16 @@ Settings config = {
     .tokenize        = TRUE,
     .matching        = "normal",
     .matching_method = MM_NORMAL,
-    /** Desktop entry fields to match*/
+
+    /** Desktop entries to match in drun */
     .drun_match_fields = "name,generic,exec,categories,keywords",
+    /** Only show entries in this category */
     .drun_categories   = NULL,
-    /**  Desktop format display */
-    .drun_display_format       = "{name} [<span weight='light' size='small'><i>({generic})</i></span>]",
     /** Desktop entry show actions */
     .drun_show_actions         = FALSE,
-    /** Desktop entry show actions */
+    /** Desktop format display */
+    .drun_display_format       = "{name} [<span weight='light' size='small'><i>({generic})</i></span>]",
+
     /** Window fields to match in window mode*/
     .window_match_fields       = "all",
     /** Monitor */
@@ -160,8 +162,11 @@ Settings config = {
 
     .cache_dir                 = NULL,
     .window_thumbnail          = FALSE,
+
+    /** drun cache */
     .drun_use_desktop_cache    = FALSE,
     .drun_reload_desktop_cache = FALSE,
+
     /** Benchmarks */
     .benchmark_ui              = FALSE
 };

--- a/include/settings.h
+++ b/include/settings.h
@@ -128,6 +128,8 @@ typedef struct
     unsigned int   drun_show_actions;
     /** Desktop format display */
     char           * drun_display_format;
+    /** Desktop Link launch command */
+    char           * drun_url_launcher;
 
     /** Search case sensitivity */
     unsigned int   case_sensitive;

--- a/include/settings.h
+++ b/include/settings.h
@@ -119,14 +119,16 @@ typedef struct
     SortingMethod  sorting_method_enum;
     /** Sorting method. */
     char           * sorting_method;
+
     /** Desktop entries to match in drun */
     char           * drun_match_fields;
     /** Only show entries in this category */
     char           * drun_categories;
     /** Desktop entry show actions */
     unsigned int   drun_show_actions;
-    /** Desktop entry show */
+    /** Desktop format display */
     char           * drun_display_format;
+
     /** Search case sensitivity */
     unsigned int   case_sensitive;
     /** Cycle through in the element list */

--- a/source/dialogs/drun.c
+++ b/source/dialogs/drun.c
@@ -61,6 +61,15 @@
 char *DRUN_GROUP_NAME = "Desktop Entry";
 
 typedef struct _DRunModePrivateData DRunModePrivateData;
+
+typedef enum
+{
+    DRUN_DESKTOP_ENTRY_TYPE_UNDETERMINED = 0,
+    DRUN_DESKTOP_ENTRY_TYPE_APPLICATION,
+    DRUN_DESKTOP_ENTRY_TYPE_LINK,
+    DRUN_DESKTOP_ENTRY_TYPE_DIRECTORY,
+} DRunDesktopEntryType;
+
 /**
  * Store extra information about the entry.
  * Currently the executable and if it should run in terminal.
@@ -86,7 +95,7 @@ typedef struct
     int             icon_size;
     /* Surface holding the icon. */
     cairo_surface_t *icon;
-    /* Executable */
+    /* Executable - for Application entries only */
     char            *exec;
     /* Name of the Entry */
     char            *name;
@@ -104,6 +113,8 @@ typedef struct
     gint            sort_index;
 
     uint32_t        icon_fetch_uid;
+
+    DRunDesktopEntryType type;
 } DRunModeEntry;
 
 typedef struct

--- a/source/dialogs/drun.c
+++ b/source/dialogs/drun.c
@@ -57,7 +57,6 @@
 
 #define DRUN_CACHE_FILE            "rofi3.druncache"
 #define DRUN_DESKTOP_CACHE_FILE    "rofi-drun-desktop.cache"
-#define XDG_OPEN_COMMAND           "xdg-open"
 
 char *DRUN_GROUP_NAME = "Desktop Entry";
 
@@ -245,9 +244,9 @@ static void launch_link_entry ( DRunModeEntry *e )
         return ;
     }
 
-    gsize command_len = strlen( XDG_OPEN_COMMAND ) + strlen( url ) + 2; // space + terminator = 2
+    gsize command_len = strlen( config.drun_url_launcher ) + strlen( url ) + 2; // space + terminator = 2
     gchar *command = g_newa ( gchar, command_len );
-    g_snprintf( command, command_len, "%s %s", XDG_OPEN_COMMAND, url );
+    g_snprintf( command, command_len, "%s %s", config.drun_url_launcher, url );
     g_free ( url );
 
     g_debug ( "Link launch command: |%s|", command );

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -135,13 +135,13 @@ static XrmOption xrmOptions[] = {
 
     { xrm_String,  "drun-match-fields",         { .str   = &config.drun_match_fields                    }, NULL,
       "Desktop entry fields to match in drun", CONFIG_DEFAULT },
-
     { xrm_String,  "drun-categories",           { .str   = &config.drun_categories                      }, NULL,
       "Only show Desktop entry from these categories", CONFIG_DEFAULT },
     { xrm_Boolean, "drun-show-actions",         { .num   = &config.drun_show_actions                    }, NULL,
       "Desktop entry show actions.", CONFIG_DEFAULT },
     { xrm_String,  "drun-display-format",       { .str   = &config.drun_display_format                  }, NULL,
       "DRUN format string. (Supports: generic,name,comment,exec,categories)", CONFIG_DEFAULT },
+
     { xrm_Boolean, "disable-history",           { .num   = &config.disable_history                      }, NULL,
       "Disable history in run/ssh", CONFIG_DEFAULT },
     { xrm_String,  "ignored-prefixes",          { .str   = &config.ignored_prefixes                     }, NULL,

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -141,6 +141,8 @@ static XrmOption xrmOptions[] = {
       "Desktop entry show actions.", CONFIG_DEFAULT },
     { xrm_String,  "drun-display-format",       { .str   = &config.drun_display_format                  }, NULL,
       "DRUN format string. (Supports: generic,name,comment,exec,categories)", CONFIG_DEFAULT },
+    { xrm_String,  "drun-url-launcher",         { .str   = &config.drun_url_launcher                    }, NULL,
+      "Command to open an Desktop Entry that is a Link.", CONFIG_DEFAULT },
 
     { xrm_Boolean, "disable-history",           { .num   = &config.disable_history                      }, NULL,
       "Disable history in run/ssh", CONFIG_DEFAULT },


### PR DESCRIPTION
__Summary__

This PR implements a solution for feature request #1166, which asked for support for "Link" type desktop entries.


__Context__

The freedesktop spec allows for "Link" type desktop entries, which contain a "URL" attribute. This is sometimes used for packages like the debian package for Folding@Home which runs a local web server for administrative functions.

__Implementation Details__

I've implemented what I think is the least-invasive solution to this problem, which is to:

- add an enum, `DRunDesktopEntryType`, representing the desktop entry type (following the names and values in the freedesktop spec)
- add a member to `DRunModeEntry` representing the desktop type
- sanity check "Application" and "Link" types separately (one requires "Exec" and the other requires "URL")
- new method `launch_link_entry` to invoke `xdg-open` with the URL
- have `drun_mode_result` check the desktop entry type and conditionally call `launch_link_entry`

Some decisions which could be revisited include:
- branching on desktop entry type inside `exec_cmd_entry` instead of the caller `drun_mode_result`
- assembling a command string in `launch_link_entry` that's then taken apart by `helper_execute_command` -- we could easily just pass an array of args around with a little additional complexity

Some things that I think make sense to implement later, only if folks ask:
- allowing the `xdg-open` command to be overridden via environment variable or configuration
- allowing URL to be a matching field in DRun searches

I'd love to hear your feedback, and am happy to edit the PR in response.