### PR TITLE
Rename SORT_FZF to SORT_FUZZY

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -46,7 +46,7 @@ typedef enum
 typedef enum
 {
     SORT_NORMAL = 0,
-    SORT_FZF    = 1
+    SORT_FUZZY  = 1
 } SortingMethod;
 
 /**

--- a/source/helper.c
+++ b/source/helper.c
@@ -555,12 +555,12 @@ int config_sanity_check ( void )
         }
         else if ( g_strcmp0 ( config.sorting_method, "levenshtein" ) == 0 ) {
             config.sorting_method_enum = SORT_NORMAL;
-        }
-        else if ( g_strcmp0 ( config.sorting_method, "fzf" ) == 0 ) {
-            config.sorting_method_enum = SORT_FZF;
-        }
-        else {
-            g_string_append_printf ( msg, "\t<b>config.sorting_method</b>=%s is not a valid sorting strategy.\nValid options are: normal or fzf.\n",
+        } else if ( g_strcmp0( config.sorting_method, "fuzzy" ) == 0 ||
+                    g_strcmp0( config.sorting_method, "fzf" ) == 0 ) {
+            // "fzf" was a misnomer. Keep it for a while for compatibility.
+            config.sorting_method_enum = SORT_FUZZY;
+        } else {
+            g_string_append_printf ( msg, "\t<b>config.sorting_method</b>=%s is not a valid sorting strategy.\nValid options are: normal or fuzzy.\n",
                                      config.sorting_method );
             found_error = 1;
         }

--- a/source/view.c
+++ b/source/view.c
@@ -605,7 +605,7 @@ static void filter_elements ( thread_state *ts, G_GNUC_UNUSED gpointer user_data
                 glong slen  = g_utf8_strlen ( str, -1 );
                 switch ( config.sorting_method_enum )
                 {
-                case SORT_FZF:
+                case SORT_FUZZY:
                     t->state->distance[i] = rofi_scorer_fuzzy_evaluate ( t->pattern, t->plen, str, slen );
                     break;
                 case SORT_NORMAL:


### PR DESCRIPTION
The fuzzy matching algorithm used to be selected by `-matching fuzzy`.  A
refactoring changed it to `-sorting-method fzf` but incorrectly attributed the
algorithm to unrelated "fzf". Rename to SORT_FUZZY and keep `-sorting-method
fzf` for a while for compatibility.