### PR TITLE
[HELP] Fix typo in help msgs

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -297,7 +297,7 @@ static void print_main_application_options ( int is_term )
     print_help_msg ( "-no-plugins", "", "Disable loading of external plugins.", NULL, is_term );
     print_help_msg ( "-plugin-path", "", "Directory used to search for rofi plugins. *DEPRECATED*", NULL, is_term );
     print_help_msg ( "-dump-config", "", "Dump the current configuration in rasi format and exit.", NULL, is_term );
-    print_help_msg ( "-upgrade-config", "", "Upgrade the old-style configuration fiel in the new rasi format and exit.", NULL, is_term );
+    print_help_msg ( "-upgrade-config", "", "Upgrade the old-style configuration file in the new rasi format and exit.", NULL, is_term );
     print_help_msg ( "-dump-theme", "", "Dump the current theme in rasi format and exit.", NULL, is_term );
 }
 static void help ( G_GNUC_UNUSED int argc, char **argv )


### PR DESCRIPTION
Just a simple typo fix in a cli help message