### PR TITLE
Remove extra colons

### DIFF
--- a/doc/create_screenshot.sh
+++ b/doc/create_screenshot.sh
@@ -8,7 +8,7 @@ echo -en "\n1\n2\n3\n4\n5"
 }
 
 sleep 5
-( shout | rofi -no-hide-scrollbar -columns 1 -width 1200 -location 0 -u 2,3 -a 4,5 -dmenu -p "Prompt:" -padding 20 -line-margin 10 -selected-row 6 ) &
+( shout | rofi -no-hide-scrollbar -columns 1 -width 1200 -location 0 -u 2,3 -a 4,5 -dmenu -p "Prompt" -padding 20 -line-margin 10 -selected-row 6 ) &
 P=$!
 sleep 5
 scrot

--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -1013,7 +1013,7 @@ Specify the prompt to show in \fB\fCdmenu\fR mode. For example, select 'monkey',
 .RS
 
 .nf
-echo "a|b|c|d|e" | rofi \-sep '|' \-dmenu \-p "monkey:"
+echo "a|b|c|d|e" | rofi \-sep '|' \-dmenu \-p "monkey"
 
 .fi
 .RE

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -604,7 +604,7 @@ Separator for `dmenu`. Example: To show a list of 'a' to 'e' with '|' as a separ
 
 Specify the prompt to show in `dmenu` mode. For example, select 'monkey', a,b,c,d, or e.
 
-    echo "a|b|c|d|e" | rofi -sep '|' -dmenu -p "monkey:"
+    echo "a|b|c|d|e" | rofi -sep '|' -dmenu -p "monkey"
 
 Default: *dmenu*
 


### PR DESCRIPTION
Rofi already adds a colon after the prompt given with -p, so the "monkey:" example would actually lead to a "monkey::" prompt.