### PR TITLE
added command line argument to only show local user desktop files

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -373,6 +373,14 @@ Default: *true*
 .RE
 
 .PP
+\fB\fC\-normalize\-match\fR
+
+.PP
+Normalize the string before matching, so o will match ö, and é matches e.
+This is not a perfect implementation, but works.
+For now it disabled highlighting of the matched part.
+
+.PP
 \fB\fC\-no\-lazy\-grab\fR
 
 .PP
@@ -518,6 +526,12 @@ Default: false
 
 .fi
 .RE
+
+.PP
+\fB\fC\-drun\-local\-only\fR
+
+.PP
+Only load desktop files from user local data directory.
 
 .PP
 \fB\fC\-window\-match\-fields\fR \fIfield1\fP,\fIfield2\fP,...
@@ -927,7 +941,7 @@ default: {w}  {c}   {t}
 \fB\fC\-window\-command\fR \fIcmd\fP
 
 .PP
-Set command to execute on selected window for a custom action.
+Set command to execute on selected window for a alt action (\fB\fC\-kb\-accept\-alt\fR).
 See \fIPATTERN\fP\&.
 
 .PP
@@ -1013,7 +1027,7 @@ Specify the prompt to show in \fB\fCdmenu\fR mode. For example, select 'monkey',
 .RS
 
 .nf
-echo "a|b|c|d|e" | rofi \-sep '|' \-dmenu \-p "monkey:"
+echo "a|b|c|d|e" | rofi \-sep '|' \-dmenu \-p "monkey"
 
 .fi
 .RE
@@ -1518,6 +1532,9 @@ Pressing the \fB\fCdelete\-entry\fR binding (\fB\fCshift\-delete\fR) will kill t
 Pressing the \fB\fCaccept\-custom\fR binding (\fB\fCcontrol\-enter\fR or \fB\fCshift\-enter\fR) will run a command on the window.
 (See option \fB\fCwindow\-command\fR );
 
+.PP
+If there is no match, it will try to launch the input.
+
 .SS run
 .PP
 Shows a list of executables in \fB\fC$PATH\fR and can launch them (optional in a terminal).
@@ -1529,7 +1546,7 @@ Pressing the \fB\fCaccept\-custom\fR binding (\fB\fCcontrol\-enter\fR or \fB\fCs
 Same as the \fBrun\fP launches, but the list is created from the installed desktop files. It automatically launches them
 in a terminal if specified in the Desktop File.
 Pressing the \fB\fCdelete\-entry\fR binding (\fB\fCshift\-delete\fR) will remove this entry from the run history.
-Pressing the \fB\fCaccept\-custom\fR binding (\fB\fCcontrol\-enter\fR or \fB\fCshift\-enter\fR) with custom input (no entry matching) will run the command in a terminal.
+Pressing the \fB\fCaccept\-custom\fR binding (\fB\fCcontrol\-enter\fR or \fB\fCshift\-enter\fR) will run the command in a terminal.
 
 .SS ssh
 .PP
@@ -1553,6 +1570,9 @@ All modi that match the bang as a prefix are included.
 For example, say you have specified \fB\fC\-combi\-modi run,window,windowcd\fR\&. If your
 query begins with the bang \fB\fC!w\fR, only results from the \fB\fCwindow\fR and \fB\fCwindowcd\fR
 modi are shown, even if the rest of the input text would match results from \fB\fCrun\fR\&.
+
+.PP
+If no match, the input is handled by the first combined modi.
 
 .SH FAQ
 .SS The text in the window switcher is not nicely aligned.

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -304,6 +304,10 @@ Show actions present in the Desktop files.
 
     Default: false
 
+`-drun-local-only`
+
+Only load desktop files from user local data directory.
+
 `-window-match-fields` *field1*,*field2*,...
 
 When using window mode, match only with the specified fields.

--- a/include/settings.h
+++ b/include/settings.h
@@ -130,6 +130,8 @@ typedef struct
     char           * drun_display_format;
     /** Desktop Link launch command */
     char           * drun_url_launcher;
+    /** Desktop Local XDG Data onlu */
+    gboolean       drun_local_desktop_only;
 
     /** Search case sensitivity */
     unsigned int   case_sensitive;
@@ -203,6 +205,8 @@ typedef struct
 
     /** Benchmark */
     gboolean       benchmark_ui;
+
+    gboolean       normalize_match;
 } Settings;
 /** Global Settings structure. */
 extern Settings config;

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -127,7 +127,7 @@ static XrmOption xrmOptions[] = {
     { xrm_String,  "run-shell-command",         { .str   = &config.run_shell_command                    }, NULL,
       "Run command to execute that runs in shell", CONFIG_DEFAULT },
     { xrm_String,  "window-command",            { .str   = &config.window_command                       }, NULL,
-      "Command executed on accep-entry-custom for window modus", CONFIG_DEFAULT },
+      "Command to executed when -kb-accept-alt binding is hit on selected window ", CONFIG_DEFAULT },
     { xrm_String,  "window-match-fields",       { .str   = &config.window_match_fields                  }, NULL,
       "Window fields to match in window mode", CONFIG_DEFAULT },
     { xrm_String,  "icon-theme",                { .str   = &config.icon_theme                           }, NULL,
@@ -143,6 +143,8 @@ static XrmOption xrmOptions[] = {
       "DRUN format string. (Supports: generic,name,comment,exec,categories)", CONFIG_DEFAULT },
     { xrm_String,  "drun-url-launcher",         { .str   = &config.drun_url_launcher                    }, NULL,
       "Command to open an Desktop Entry that is a Link.", CONFIG_DEFAULT },
+    { xrm_Boolean, "drun-local-only",         { .num   = &config.drun_local_desktop_only}, NULL,
+      "Only show Desktop entry in user home data directiory", CONFIG_DEFAULT },
 
     { xrm_Boolean, "disable-history",           { .num   = &config.disable_history                      }, NULL,
       "Disable history in run/ssh", CONFIG_DEFAULT },
@@ -231,6 +233,8 @@ static XrmOption xrmOptions[] = {
       "DRUN: build and use a cache with desktop file content.", CONFIG_DEFAULT },
     { xrm_Boolean, "drun-reload-desktop-cache", { .snum  = &config.drun_reload_desktop_cache            }, NULL,
       "DRUN: If enabled, reload the cache with desktop file content.", CONFIG_DEFAULT },
+    { xrm_Boolean, "normalize-match", 		      { .snum  = &config.normalize_match                      }, NULL,
+            "Normalize string when matching (implies -no-show-match).", CONFIG_DEFAULT },
 };
 
 /** Dynamic array of extra options */


### PR DESCRIPTION
I found that pruning my desktop files that belong to the entire system to shorten my rofi drun list was proving difficult.

I've added another command line argument 
    -drun-local-only

When this argument is passed, it only reads the desktop files from the user and skips the walk of system directories.

That way the desktop files purposely placed in the ".local/share/application" folder are the only ones shown in the menu.

I hope I got the man page updates correct. Let me know if there is some documentation I'd need to update that I missed