### PR TITLE
Add Action to auto-close incomplete reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,26 +6,52 @@ title: "[REQUEST] "
 assignees: ''
 ---
 
-**Before creating a feature request:**
-- First check the *next* branch, to see if the feature has already been
-  implemented.
-- Check existing reports, see if it is already requested.
+:exclamation:
+First read the [guidelines](https://github.com/DaveDavenport/rofi/blob/next/.github/CONTRIBUTING.md)!
+This is not optional for any report/question. People must be able to understand the full context of the report when reading it, at any time.
+If you feel like you “just have a simple question”, please consider you’re wrong and still fill the full report.
+Any report missing these informations will be labeled as “Incomplete Report - Please follow the guidelines” and may not be answered in a timely fashion.
+:exclamation:
+
+## Before creating a feature request
+- [ ] I checked the *next* branch to see if the feature has already been
+  implemented
+- [ ] I searched existing reports to see if it is already requested.
 
 
-**Describe the feature**
-- A clear description of the feature you want added.
-- If the feature involves replacement of current functionality, how the new
-  functionality is better?
-- If the feature is implemented in another application, include:
-  - Screenshots or screencasts of it
-  - Links to its implementation
-- If possible try to explain how you would expect to use feature:
-  For example, should it be a configuration option or a hot-key. 
+## What is the user problem or growth opportunity you want to see solved?
+
+...
 
 
-**When reporting a feature request include the following information:**
-- Rofi version:
-  - `rofi -v`
+## How do you know that this problem exists today? Why is this important?
+
+...
+
+
+## Who will benefit from it?
+
+...
+
+
+## Version
+
+Output of `rofi -v`
+
+
+## Configuration
+
+Output of `rofi -help` (in a [gist](https://gist.github.com/), please paste the *full* output)
+
+
+**Additional details:**
+- Include a link to your private config
+- Include screenshots/casts of your issue
+
+
+**Please do not submit reports related to wayland, see
+[here](https://github.com/DaveDavenport/rofi/wiki/Wayland) for more
+information.**
 
 
 **Requesting a feature is no guarantee it will be added.**

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  auto_close_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Automatically close issues that don't follow the issue template
+        uses: ergo720/auto-close-issues@v1.0.4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-close-message: "@${issue.user.login}: hello! :wave:\n\nThis issue is being automatically closed because it does not follow the issue template." # optional property
+          closed-issues-label: "Incomplete Report - Please follow the guidelines" # optional property


### PR DESCRIPTION
This PR adds an action that auto-close incomplete reports. It works with all the templates in `.github/ISSUE_TEMPLATES` folder. 

@DaveDavenport should we fork the Action repository in Davatorium to prevent a scenario where the author deletes it? If yes, we'll need to change the line 13 in `.github/workflows/main.yml`.
