### PR TITLE
docs: fix simple typo, prefered -> preferred

### DIFF
--- a/source/xcb.c
+++ b/source/xcb.c
@@ -63,9 +63,9 @@
 
 #include <rofi.h>
 
-/** Minimal randr prefered for running rofi (1.5) (Major version number) */
+/** Minimal randr preferred for running rofi (1.5) (Major version number) */
 #define RANDR_PREF_MAJOR_VERSION    1
-/** Minimal randr prefered for running rofi (1.5) (Minor version number) */
+/** Minimal randr preferred for running rofi (1.5) (Minor version number) */
 #define RANDR_PREF_MINOR_VERSION    5
 
 /** Checks if the if x and y is inside rectangle. */


### PR DESCRIPTION
There is a small typo in source/xcb.c.

Should read `preferred` rather than `prefered`.

