### PR TITLE
Added -hover-select option that automatically selects the entry under the cursor

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -711,6 +711,19 @@ rofi \-show run \-sidebar\-mode \-lines 0
 .RE
 
 .PP
+Automatically select the entry the mouse is hovering over. This option is best combined with custom mouse bindings.
+To utilize hover\-select and accept an entry in a single click, use:
+
+.PP
+.RS
+
+.nf
+rofi \-show run \-hover\-select \-me\-select\-entry '' -me\-accept\-entry MousePrimary
+
+.fi
+.RE
+
+.PP
 \fB\fC\-eh\fR \fInumber\fP
 
 .PP

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -403,6 +403,13 @@ To show sidebar, use:
 
     rofi -show run -sidebar-mode -lines 0
 
+`-hover-select`
+
+Automatically select the entry the mouse is hovering over. This option is best combined with custom mouse bindings.
+To utilize hover-select and accept an entry in a single click, use:
+
+    rofi -show run -hover-select -me-select-entry '' -me-accept-entry MousePrimary
+
 `-eh` *number*
 
 Set row height (in chars)

--- a/include/settings.h
+++ b/include/settings.h
@@ -139,6 +139,8 @@ typedef struct
     int            element_height;
     /** Sidebar mode, show the modi */
     unsigned int   sidebar_mode;
+    /** Mouse hover automatically selects */
+    unsigned int   hover_select;
     /** Lazy filter limit. */
     unsigned int   lazy_filter_limit;
     /** Auto select. */

--- a/include/view.h
+++ b/include/view.h
@@ -100,10 +100,11 @@ void rofi_view_handle_text ( RofiViewState *state, char *text );
  * @param state the Menu handle
  * @param x The X coordinates of the motion
  * @param y The Y coordinates of the motion
+ * @param find_mouse_target if we should handle pure mouse motion
  *
  * Update the state if needed.
  */
-void rofi_view_handle_mouse_motion ( RofiViewState *state, gint x, gint y );
+void rofi_view_handle_mouse_motion ( RofiViewState *state, gint x, gint y, gboolean find_mouse_target );
 /**
  * @param state the Menu handle
  *

--- a/source/view.c
+++ b/source/view.c
@@ -730,14 +730,18 @@ static void rofi_view_setup_fake_transparency ( const char* const fake_backgroun
 }
 void __create_window ( MenuFlags menu_flags )
 {
-    uint32_t          selmask  = XCB_CW_BACK_PIXMAP | XCB_CW_BORDER_PIXEL | XCB_CW_BIT_GRAVITY | XCB_CW_BACKING_STORE | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP;
+    uint32_t selmask         = XCB_CW_BACK_PIXMAP | XCB_CW_BORDER_PIXEL | XCB_CW_BIT_GRAVITY | XCB_CW_BACKING_STORE | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP;
+    uint32_t xcb_event_masks = XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE |
+                               XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_KEY_RELEASE | XCB_EVENT_MASK_KEYMAP_STATE |
+                               XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_BUTTON_1_MOTION;
+    if ( config.hover_select == TRUE ) {
+        xcb_event_masks |= XCB_EVENT_MASK_POINTER_MOTION;
+    }
     uint32_t          selval[] = {
-        XCB_BACK_PIXMAP_NONE,                                                                           0,
+        XCB_BACK_PIXMAP_NONE,         0,
         XCB_GRAVITY_STATIC,
         XCB_BACKING_STORE_NOT_USEFUL,
-        XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE |
-        XCB_EVENT_MASK_KEY_PRESS | XCB_EVENT_MASK_KEY_RELEASE | XCB_EVENT_MASK_KEYMAP_STATE |
-        XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_BUTTON_1_MOTION,
+        xcb_event_masks,
         map
     };
 
@@ -1481,13 +1485,22 @@ void rofi_view_handle_text ( RofiViewState *state, char *text )
     }
 }
 
-void rofi_view_handle_mouse_motion ( RofiViewState *state, gint x, gint y )
+void rofi_view_handle_mouse_motion ( RofiViewState *state, gint x, gint y, gboolean find_mouse_target )
 {
     state->mouse.x = x;
     state->mouse.y = y;
+    if ( find_mouse_target ) {
+        widget *target = widget_find_mouse_target ( WIDGET ( state->main_window ), SCOPE_MOUSE_LISTVIEW_ELEMENT, x, y );
+        if ( target != NULL ) {
+            state->mouse.motion_target = target;
+        }
+    }
     if ( state->mouse.motion_target != NULL ) {
         widget_xy_to_relative ( state->mouse.motion_target, &x, &y );
         widget_motion_notify ( state->mouse.motion_target, x, y );
+        if ( find_mouse_target ) {
+            state->mouse.motion_target = NULL;
+        }
     }
 }
 

--- a/source/xcb.c
+++ b/source/xcb.c
@@ -914,11 +914,12 @@ static void main_loop_x11_event_handler_view ( xcb_generic_event_t *event )
     }
     case XCB_MOTION_NOTIFY:
     {
-        if ( config.click_to_exit == TRUE ) {
+        xcb_motion_notify_event_t *xme        = (xcb_motion_notify_event_t *) event;
+        gboolean                  button_mask = xme->state & XCB_EVENT_MASK_BUTTON_1_MOTION;
+        if (  button_mask && config.click_to_exit == TRUE ) {
             xcb->mouse_seen = TRUE;
         }
-        xcb_motion_notify_event_t *xme = (xcb_motion_notify_event_t *) event;
-        rofi_view_handle_mouse_motion ( state, xme->event_x, xme->event_y );
+        rofi_view_handle_mouse_motion ( state, xme->event_x, xme->event_y, !button_mask );
         break;
     }
     case XCB_BUTTON_PRESS:
@@ -929,7 +930,7 @@ static void main_loop_x11_event_handler_view ( xcb_generic_event_t *event )
         gint32                   steps;
 
         xcb->last_timestamp = bpe->time;
-        rofi_view_handle_mouse_motion ( state, bpe->event_x, bpe->event_y );
+        rofi_view_handle_mouse_motion ( state, bpe->event_x, bpe->event_y, FALSE );
         if ( x11_button_to_nk_bindings_button ( bpe->detail, &button ) ) {
             nk_bindings_seat_handle_button ( xcb->bindings_seat, NULL, button, NK_BINDINGS_BUTTON_STATE_PRESS, bpe->time );
         }

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -158,6 +158,8 @@ static XrmOption xrmOptions[] = {
       "Cycle through the results list", CONFIG_DEFAULT },
     { xrm_Boolean, "sidebar-mode",              { .num   = &config.sidebar_mode                         }, NULL,
       "Enable sidebar-mode", CONFIG_DEFAULT },
+    { xrm_Boolean, "hover-select",              { .num   = &config.hover_select                         }, NULL,
+      "Enable hover-select", CONFIG_DEFAULT },
     { xrm_SNumber, "eh",                        { .snum  = &config.element_height                       }, NULL,
       "Row height (in chars)", CONFIG_DEFAULT },
     { xrm_Boolean, "auto-select",               { .num   = &config.auto_select                          }, NULL,


### PR DESCRIPTION
This pull request addresses #600 and adds the `-hover-select` config/command-line option to select the entry currently under the mouse.

 I did not make this option change any existing key-bindings. I tried to include relevant documentation, and the implementation should be reasonably efficient (no forcing unneeded redraws).