### PR TITLE
add prefix matching method feature

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -439,6 +439,8 @@ Current the following methods are supported.
 \fBglob\fP: match a glob pattern
 .IP \(bu 2
 \fBfuzzy\fP: do a fuzzy match
+.IP \(bu 2
+\fBprefix\fP: match prefix
 
 .PP
 Default: \fInormal\fP

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -218,7 +218,7 @@ Show the indicator that shows what part of the string is matched.
 
 Normalize the string before matching, so o will match ö, and é matches e.
 This is not a perfect implementation, but works.
-For now it disabled highlighting of the matched part. 
+For now it disabled highlighting of the matched part.
 
 `-no-lazy-grab`
 
@@ -261,6 +261,7 @@ Current the following methods are supported.
 * **regex**: match a regex input
 * **glob**: match a glob pattern
 * **fuzzy**: do a fuzzy match
+* **prefix**: match prefix
 
    Default: *normal*
 

--- a/doc/test_xr.txt
+++ b/doc/test_xr.txt
@@ -31,7 +31,7 @@ rofi.ssh-command:                    {terminal} -e {ssh-client} {host}
 ! "Run command to execute" Set from: File
 rofi.run-command:                    bash -c "{cmd}"
 ! "Command to get extra run targets" Set from: Default
-! rofi.run-list-command:               
+! rofi.run-list-command:
 ! "Run command to execute that runs in shell" Set from: File
 rofi.run-shell-command:              {terminal} -e {cmd}
 ! "Command executed on accep-entry-custom for window modus" Set from: File
@@ -39,11 +39,11 @@ rofi.window-command:                 xkill -id {window}
 ! "Window fields to match in window mode" Set from: Default
 ! rofi.window-match-fields:            all
 ! "Theme to use to look for icons" Set from: Default
-! rofi.icon-theme:                     
+! rofi.icon-theme:
 ! "Desktop entry fields to match in drun" Set from: Default
 ! rofi.drun-match-fields:              name,generic,exec,categories,keywords
 ! "Only show Desktop entry from these categories" Set from: Default
-! rofi.drun-categories:                
+! rofi.drun-categories:
 ! "Desktop entry show actions." Set from: Default
 ! rofi.drun-show-actions:              false
 ! "DRUN format string. (Supports: generic,name,comment,exec,categories)" Set from: Default
@@ -51,11 +51,11 @@ rofi.window-command:                 xkill -id {window}
 ! "Disable history in run/ssh" Set from: File
 rofi.disable-history:                false
 ! "Programs ignored for history" Set from: Default
-! rofi.ignored-prefixes:               
+! rofi.ignored-prefixes:
 ! "Use sorting" Set from: Default
 ! rofi.sort:                           false
 ! "Choose the strategy used for sorting: normal (levenshtein) or fzf." Set from: Default
-! rofi.sorting-method:                 
+! rofi.sorting-method:
 ! "Set case-sensitivity" Set from: File
 rofi.case-sensitive:                 false
 ! "Cycle through the results list" Set from: File
@@ -72,7 +72,7 @@ rofi.parse-hosts:                    false
 rofi.parse-known-hosts:              true
 ! "Set the modi to combine in combi mode" Set from: File
 rofi.combi-modi:                     window,drun,run,ssh
-! "Set the matching algorithm. (normal, regex, glob, fuzzy)" Set from: Default
+! "Set the matching algorithm. (normal, regex, glob, fuzzy, prefix)" Set from: Default
 ! rofi.matching:                       normal
 ! "Tokenize input string" Set from: File
 rofi.tokenize:                       true
@@ -83,7 +83,7 @@ rofi.m:                              -1
 ! "Padding within rows *DEPRECATED*" Set from: Default
 ! rofi.line-padding:                   1
 ! "Pre-set filter" Set from: Default
-! rofi.filter:                         
+! rofi.filter:
 ! "Separator style (none, dash, solid) *DEPRECATED*" Set from: Default
 ! rofi.separator-style:                dash
 ! "Hide scroll-bar *DEPRECATED*" Set from: Default
@@ -109,15 +109,15 @@ rofi.scroll-method:                  0
 ! "Indicate how it match by underlining it." Set from: Default
 ! rofi.show-match:                     true
 ! "New style theme file" Set from: Default
-! rofi.theme:                          
+! rofi.theme:
 ! "Color scheme for normal row" Set from: Default
-! rofi.color-normal:                   
+! rofi.color-normal:
 ! "Color scheme for urgent row" Set from: Default
-! rofi.color-urgent:                   
+! rofi.color-urgent:
 ! "Color scheme for active row" Set from: Default
-! rofi.color-active:                   
+! rofi.color-active:
 ! "Color scheme window" Set from: Default
-! rofi.color-window:                   
+! rofi.color-window:
 ! "Max history size (WARNING: can cause slowdowns when set to high)." Set from: Default
 ! rofi.max-history-size:               25
 ! "Hide the prefix mode prefix on the combi view." Set from: Default
@@ -125,7 +125,7 @@ rofi.scroll-method:                  0
 ! "Set the character used to negate the matching. ('\0' to disable)" Set from: Default
 ! rofi.matching-negate-char:           -
 ! "Directory where history and temporary files are stored." Set from: Default
-! rofi.cache-dir:                      
+! rofi.cache-dir:
 ! "Show window thumbnail in window switcher if availalbe." Set from: Default
 ! rofi.window-thumbnail:               false
 ! "Pidfile location" Set from: File

--- a/include/settings.h
+++ b/include/settings.h
@@ -40,7 +40,8 @@ typedef enum
     MM_NORMAL = 0,
     MM_REGEX  = 1,
     MM_GLOB   = 2,
-    MM_FUZZY  = 3
+    MM_FUZZY  = 3,
+    MM_PREFIX = 4
 } MatchingMethod;
 
 /**

--- a/source/helper.c
+++ b/source/helper.c
@@ -179,6 +179,18 @@ static gchar *fuzzy_to_regex ( const char * input )
     return retv;
 }
 
+static gchar *prefix_regex (const char * input)
+{
+    gchar *r = g_regex_escape_string(input, -1);
+    GString *str = g_string_new(r);
+    g_string_prepend(str, "\\b");
+    g_free(r);
+    char *retv = str->str;
+    g_string_free(str, FALSE);
+    return retv;
+
+}
+
 static char *utf8_helper_simplify_string ( const char *s )
 {
     gunichar buf2[G_UNICHAR_MAX_DECOMPOSITION_LENGTH] = { 0, };
@@ -247,6 +259,11 @@ static rofi_int_matcher * create_regex ( const char *input, int case_sensitive )
         r    = fuzzy_to_regex ( input );
         retv = R ( r, case_sensitive );
         g_free ( r );
+        break;
+    case MM_PREFIX:
+        r = prefix_regex(input);
+        retv = R(r, case_sensitive);
+        g_free(r);
         break;
     default:
         r    = g_regex_escape_string ( input, -1 );
@@ -632,8 +649,11 @@ int config_sanity_check ( void )
         else if ( g_strcmp0 ( config.matching, "normal" ) == 0 ) {
             config.matching_method = MM_NORMAL;;
         }
+        else if (g_strcmp0 (config.matching, "prefix") == 0) {
+            config.matching_method = MM_PREFIX;
+        }
         else {
-            g_string_append_printf ( msg, "\t<b>config.matching</b>=%s is not a valid matching strategy.\nValid options are: glob, regex, fuzzy or normal.\n",
+            g_string_append_printf ( msg, "\t<b>config.matching</b>=%s is not a valid matching strategy.\nValid options are: glob, regex, fuzzy, prefix or normal.\n",
                                      config.matching );
             found_error = 1;
         }

--- a/source/helper.c
+++ b/source/helper.c
@@ -184,7 +184,7 @@ static gchar *prefix_regex (const char * input)
     gchar *r = g_regex_escape_string(input, -1);
     char *retv = g_strconcat("\\b", r, NULL);
     g_free(r);
-    return retv  
+    return retv;
 }
 
 static char *utf8_helper_simplify_string ( const char *s )

--- a/source/helper.c
+++ b/source/helper.c
@@ -181,7 +181,10 @@ static gchar *fuzzy_to_regex ( const char * input )
 
 static gchar *prefix_regex (const char * input)
 {
-    return g_strconcat("\\b", g_regex_escape_string(input, -1), NULL);
+    gchar *r = g_regex_escape_string(input, -1);
+    char *retv = g_strconcat("\\b", r, NULL);
+    g_free(r);
+    return retv  
 }
 
 static char *utf8_helper_simplify_string ( const char *s )

--- a/source/helper.c
+++ b/source/helper.c
@@ -181,14 +181,7 @@ static gchar *fuzzy_to_regex ( const char * input )
 
 static gchar *prefix_regex (const char * input)
 {
-    gchar *r = g_regex_escape_string(input, -1);
-    GString *str = g_string_new(r);
-    g_string_prepend(str, "\\b");
-    g_free(r);
-    char *retv = str->str;
-    g_string_free(str, FALSE);
-    return retv;
-
+    return g_strconcat("\\b", g_regex_escape_string(input, -1), NULL);
 }
 
 static char *utf8_helper_simplify_string ( const char *s )

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -169,7 +169,7 @@ static XrmOption xrmOptions[] = {
     { xrm_String,  "combi-modi",                { .str   = &config.combi_modi                           }, NULL,
       "Set the modi to combine in combi mode", CONFIG_DEFAULT },
     { xrm_String,  "matching",                  { .str   = &config.matching                             }, NULL,
-      "Set the matching algorithm. (normal, regex, glob, fuzzy)", CONFIG_DEFAULT },
+      "Set the matching algorithm. (normal, regex, glob, fuzzy, prefix)", CONFIG_DEFAULT },
     { xrm_Boolean, "tokenize",                  { .num   = &config.tokenize                             }, NULL,
       "Tokenize input string", CONFIG_DEFAULT },
     { xrm_String,  "monitor",                   { .str   = &config.monitor                              }, NULL,


### PR DESCRIPTION
With the normal matching method, most of the time, there are too many results, which means more key press is needed to get what I want. With the fuzzy matching method, even more results!
So I made this prefix matching method, which can **_quickly narrow down_** the query results, help me to get the target result **_as less key press as possible_**.
Of course, add a '\b' before each keyword with regex matching method can also do the work, but apparently I will not likely to type extra same keys before each keyword.
Hope it useful for others.
