### PR TITLE
Fix drun prompt in sidebar theme.

### DIFF
--- a/themes/sidebar.rasi
+++ b/themes/sidebar.rasi
@@ -108,3 +108,15 @@ error-message {
     border: 2px;
     padding: 1em;
 }
+
+inputbar {
+    children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
+}
+
+textbox-prompt-colon {
+    expand:     false;
+    str:        ":";
+    margin:     0px 0.3em 0em 0em ;
+    text-color: @normal-foreground;
+}
+


### PR DESCRIPTION
There is an error in the `sidebar.rasi` theme where the `drun` prompt will display as `drun` and not `drun: `. I have added the relevant code in order to patch this.