### PR TITLE
configure.ac: Remove argument from AC_PROG_LEX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AH_BOTTOM([#include "gitconfig.h"])
 dnl ---------------------------------------------------------------------
 dnl Lex & Bison language parser.
 dnl ---------------------------------------------------------------------
-AC_PROG_LEX([flex])
+AC_PROG_LEX
 AC_PROG_YACC
 
 


### PR DESCRIPTION
`autoconf-2.70` only accepts "yywrap" and "noyywrap" as arguments to
`AC_PROG_LEX`. Calling it with no arguments will trigger the old behavior
from `autoconf-2.69`.

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>

If called unchanged, `aclocal` fails like this:
```
***** aclocal *****
***** PWD: /var/tmp/portage/x11-misc/rofi-1.6.1/work/rofi-1.6.1
***** aclocal -I subprojects/libnkutils -I subprojects/libgwater

configure.ac:10: error: AC_PROG_LEX: unrecognized argument: flex
./lib/autoconf/programs.m4:716: _AC_PROG_LEX is expanded from...
./lib/autoconf/programs.m4:709: AC_PROG_LEX is expanded from...
configure.ac:10: the top level
autom4te-2.70: error: /usr/bin/m4 failed with exit status: 1
aclocal-1.16: error: autom4te failed with exit status: 1
```

Please also see the responsible [autoconf upstream commit](http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commit;h=46f384f850b455cdb366bafbcf4e992606b3f2c0)