### PR TITLE
Add 'small caps' to 'Text Style' format in manpage

### DIFF
--- a/doc/rofi-theme.5
+++ b/doc/rofi-theme.5
@@ -1,3 +1,4 @@
+.nh
 .TH ROFI\-THEME 5 rofi\-theme
 .SH NAME
 .PP
@@ -95,7 +96,7 @@ abbreviation for \fBr\fPofi \fBa\fPdvanced \fBs\fPtyle \fBi\fPnformation.
 .SH Basic Structure
 .PP
 Each element has a section with defined properties. Global properties can be defined in section \fB\fC* { }\fR\&.
-Sub\-section names begin with a hash symbol \fB\fC#\fR\&.
+Sub\-\&section names begin with a hash symbol \fB\fC#\fR\&.
 
 .PP
 It is advised to define the \fIglobal properties section\fP on top of the file to
@@ -424,11 +425,7 @@ The different values are:
 .IP \(bu 2
 \fB\fC{PERCENTAGE}\fR can be between 0\-1.0, or 0%\-100%
 .IP \(bu 2
-
-.PP
-\fB\fC{named\-color}\fR is one of the following colors:
-.PP
-AliceBlue, AntiqueWhite, Aqua, Aquamarine, Azure, Beige, Bisque, Black, BlanchedAlmond, Blue, BlueViolet, Brown,
+\fB\fC{named\-color}\fR is one of the following colors:AliceBlue, AntiqueWhite, Aqua, Aquamarine, Azure, Beige, Bisque, Black, BlanchedAlmond, Blue, BlueViolet, Brown,
 BurlyWood, CadetBlue, Chartreuse, Chocolate, Coral, CornflowerBlue, Cornsilk, Crimson, Cyan, DarkBlue, DarkCyan,
 DarkGoldenRod, DarkGray, DarkGrey, DarkGreen, DarkKhaki, DarkMagenta, DarkOliveGreen, DarkOrange, DarkOrchid, DarkRed,
 DarkSalmon, DarkSeaGreen, DarkSlateBlue, DarkSlateGray, DarkSlateGrey, DarkTurquoise, DarkViolet, DeepPink, DeepSkyBlue,
@@ -475,7 +472,7 @@ text\-color: Black;
 .SH Text style
 .RS
 .IP \(bu 2
-Format: \fB\fC(bold|italic|underline|strikethrough|none)\fR
+Format: \fB\fC(bold|italic|underline|strikethrough|small caps|snone)\fR
 
 .RE
 
@@ -502,6 +499,7 @@ should be applied.
 
 .PP
 For some reason \fB\fCsmall caps\fR does not work on some systems.
+
 .RE
 
 .SH Line style
@@ -669,6 +667,7 @@ style property.
 
 .PP
 When no unit is specified, pixels are assumed.
+
 .RE
 
 .SH Position
@@ -677,22 +676,14 @@ Indicate a place on the window/monitor.
 
 .RS
 .IP \(bu 2
-
-.PP
 Format: \fB\fC(center|east|north|west|south|north east|north west|south west|south east)\fR
-.PP
-.RS
-
-.nf
-
+\fB\fC
 north west   |    north    |  north east
 \-\-\-\-\-\-\-\-\-\-\-\-\-|\-\-\-\-\-\-\-\-\-\-\-\-\-|\-\-\-\-\-\-\-\-\-\-\-\-
   west   |   center    |  east
 \-\-\-\-\-\-\-\-\-\-\-\-\-|\-\-\-\-\-\-\-\-\-\-\-\-\-|\-\-\-\-\-\-\-\-\-\-\-\-
 south west   |    south    |  south east
-
-.fi
-.RE
+\fR
 
 .RE
 
@@ -854,7 +845,6 @@ The current widgets available in \fBrofi\fP:
 .RS
 .IP \(bu 2
 \fB\fCwindow\fR
-
 .RS
 .IP \(bu 2
 \fB\fCoverlay\fR: the overlay widget.
@@ -862,7 +852,6 @@ The current widgets available in \fBrofi\fP:
 \fB\fCmainbox\fR: The mainbox box.
 .IP \(bu 2
 \fB\fCinputbar\fR: The input bar box.
-
 .RS
 .IP \(bu 2
 \fB\fCbox\fR: the horizontal @box packing the widgets
@@ -878,15 +867,14 @@ The current widgets available in \fBrofi\fP:
 \fB\fCnum\-filtered\-rows\fR: Shows the total number of rows after filtering.
 
 .RE
+
 .IP \(bu 2
 \fB\fClistview\fR: The listview.
-
 .RS
 .IP \(bu 2
 \fB\fCscrollbar\fR: the listview scrollbar
 .IP \(bu 2
 \fB\fCelement\fR: a box in the listview holding the entries
-
 .RS
 .IP \(bu 2
 \fB\fCelement\-icon\fR: the widget in the listview's entry showing the (optional) icon
@@ -897,25 +885,28 @@ The current widgets available in \fBrofi\fP:
 
 .RE
 
+
 .RE
+
 .IP \(bu 2
 \fB\fCmode\-switcher\fR: the main horizontal @box packing the buttons.
-
 .RS
 .IP \(bu 2
 \fB\fCbutton\fR: the buttons @textbox for each mode
 
 .RE
+
 .IP \(bu 2
 \fB\fCmessage\fR: The container holding the textbox.
-
 .RS
 .IP \(bu 2
 \fB\fCtextbox\fR: the message textbox
 
 .RE
 
+
 .RE
+
 
 .RE
 
@@ -1018,13 +1009,9 @@ Color of the border
 .SS window:
 .RS
 .IP \(bu 2
-
-.PP
 \fBfont\fP:            string
 The font used in the window
 .IP \(bu 2
-
-.PP
 \fBtransparency\fP:    string
 Indicating if transparency should be used and what type:
 \fBreal\fP \- True transparency. Only works with a compositor.
@@ -1032,32 +1019,20 @@ Indicating if transparency should be used and what type:
 \fBscreenshot\fP \- Take a screenshot of the screen and use that.
 \fBPath\fP to png file \- Use an image.
 .IP \(bu 2
-
-.PP
 \fBlocation\fP:       position
 The place of the anchor on the monitor
 .IP \(bu 2
-
-.PP
 \fBanchor\fP:         anchor
 The anchor position on the window
 .IP \(bu 2
-
-.PP
 \fBfullscreen\fP:     boolean
 Window is fullscreen.
 .IP \(bu 2
-
-.PP
 \fBwidth\fP:          distance
 The width of the window
 .IP \(bu 2
-
-.PP
 \fBx\-offset\fP:  distance
 .IP \(bu 2
-
-.PP
 \fBy\-offset\fP:  distance
 The offset of the window to the anchor point, allowing you to push the window left/right/up/down
 
@@ -1257,6 +1232,7 @@ The current layout of \fBrofi\fP is structured as follows:
 
 .PP
 ci is the case\-indicator
+
 .RE
 
 .SS Error message structure

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -306,7 +306,7 @@ text-color: Black;
 
 ## Text style
 
-* Format: `(bold|italic|underline|strikethrough|none)`
+* Format: `(bold|italic|underline|strikethrough|small caps|snone)`
 
 Text style indicates how the highlighted text is emphasized. `None` indicates that no emphasis
 should be applied.


### PR DESCRIPTION
'small caps' is listed in 'Text Style.IP' section in 'rofi-theme.5' and also
[lexer treat it](https://github.com/davatorium/rofi/blob/413eddd825e7c5bc6699352c989d994a40b357c1/lexer/theme-lexer.l#L212), but this wasn't in 'format' regex shown there.

Therefore, I thought it's missing, added it.

P.S. I'm a bit confused by output of 'go-md2man' as it seems to modify more than what I changed, but I committed it as is.
