### PR TITLE
Minimize rebuilds on git version change

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,6 @@ AC_INIT([rofi], [1.6.1-dev], [https://github.com/davatorium/rofi/],[],[https://r
 
 AC_CONFIG_SRCDIR([source/rofi.c])
 AC_CONFIG_HEADER([config.h])
-AH_BOTTOM([#include "gitconfig.h"])
 
 dnl ---------------------------------------------------------------------
 dnl Lex & Bison language parser.

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -48,10 +48,12 @@
 #include <libgwater-xcb.h>
 
 #ifdef USE_NK_GIT_VERSION
-#include "nkutils-git-version.h"
-#ifdef NK_GIT_VERSION
-#define GIT_VERSION    NK_GIT_VERSION
-#endif
+    #include "nkutils-git-version.h"
+    #ifdef NK_GIT_VERSION
+        #define GIT_VERSION    NK_GIT_VERSION
+    #endif
+#else
+    #include <gitconfig.h>
 #endif
 
 #include "resources.h"


### PR DESCRIPTION
For now full rebuild happens when current commit changes, which may happen without actual content change - e.g. something is commited or uncommited via `git reset` without `--hard` option. This change makes only necessary files being rebuild - those, using GIT_REVISION.