### PR TITLE
[FileBrowser] Allow setting startup directory

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -128,6 +128,9 @@ Settings config = {
     /** Desktop Link launch command */
     .drun_url_launcher         = "xdg-open",
 
+    /** Directory the file browser starts in */
+    .file_browser_directory = NULL,
+
     /** Window fields to match in window mode*/
     .window_match_fields       = "all",
     /** Monitor */

--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -1181,6 +1181,19 @@ Set ellipsize mode to start. So end of string is visible.
 Pops up a message dialog (used internally for showing errors) with \fImessage\fP\&.
 Message can be multi\-line.
 
+.SS File browser settings
+.PP
+\fB\fC\-file\-browser\-directory\fR \fIdirectory\fP
+
+.PP
+Directory the file browser starts in.
+
+.PP
+.RS
+
+.fi
+.RE
+
 .SS Other
 .PP
 \fB\fC\-drun\-use\-desktop\-cache\fR

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -721,6 +721,12 @@ Set ellipsize mode to start. So end of string is visible.
 Pops up a message dialog (used internally for showing errors) with *message*.
 Message can be multi-line.
 
+### File browser settings
+
+`-file-browser-directory` *directory*
+
+Directory the file browser starts in.
+
 ### Other
 
 `-drun-use-desktop-cache`

--- a/include/settings.h
+++ b/include/settings.h
@@ -132,6 +132,9 @@ typedef struct
     /** Desktop Link launch command */
     char           * drun_url_launcher;
 
+    /** Directory the file browser starts in */
+    char           * file_browser_directory;
+
     /** Search case sensitivity */
     unsigned int   case_sensitive;
     /** Cycle through in the element list */

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -145,6 +145,9 @@ static XrmOption xrmOptions[] = {
     { xrm_String,  "drun-url-launcher",         { .str   = &config.drun_url_launcher                    }, NULL,
       "Command to open an Desktop Entry that is a Link.", CONFIG_DEFAULT },
 
+    { xrm_String,  "file-browser-directory",    { .str   = &config.file_browser_directory               }, NULL,
+      "Directory the file browser starts in", CONFIG_DEFAULT },
+
     { xrm_Boolean, "disable-history",           { .num   = &config.disable_history                      }, NULL,
       "Disable history in run/ssh", CONFIG_DEFAULT },
     { xrm_String,  "ignored-prefixes",          { .str   = &config.ignored_prefixes                     }, NULL,


### PR DESCRIPTION
Adds a new option - `-file-browser-directory` that allows specifying the file browser startup directory.

Closes #1259