### PR TITLE
Fix minor typos in theming notice

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -565,14 +565,14 @@ Default: '\-'
 .fi
 .RE
 
-.SS Layout and Themeing
+.SS Layout and Theming
 .PP
-\fBIMPORTANT\fP
-  In newer \fBrofi\fP releases all the themeing options are moved into the new theme format. The are no longer normal
-  \fBrofi\fP options that can be passed directly on the commandline (there are to many).
+\fBIMPORTANT:\fP
+  In newer \fBrofi\fP releases, all the theming options have been moved into the new theme format. They are no longer normal
+  \fBrofi\fP options that can be passed directly on the commandline (there are too many).
   Small snippets can be passed on the commandline: \fB\fCrofi \-theme\-str 'window {width: 50%;}'\fR to override a single
-  setting. The are merged into the current theme.
-  They can also be appened at the end of the \fBrofi\fP config file to override parts of the theme.
+  setting. They are merged into the current theme.
+  They can also be appended to the end of the \fBrofi\fP config file to override parts of the theme.
 
 .PP
 Most of the following options are \fBdeprecated\fP and should not be used. Please use the new theme format to customize
@@ -1247,7 +1247,7 @@ ln \-s /usr/bin/rofi /usr/bin/dmenu
 
 .SH THEMING
 .PP
-Please see \fBrofi\-theme(5)\fP manpage for more information on themeing.
+Please see \fBrofi\-theme(5)\fP manpage for more information on theming.
 
 .SH KEY BINDINGS
 .PP

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -322,14 +322,14 @@ Set to '\x0' to disable.
     Default: '-'
 
 
-### Layout and Themeing
+### Layout and Theming
 
-**IMPORTANT**
-  In newer **rofi** releases all the themeing options are moved into the new theme format. The are no longer normal
-  **rofi** options that can be passed directly on the commandline (there are to many).
+**IMPORTANT:**
+  In newer **rofi** releases, all the theming options have been moved into the new theme format. They are no longer normal
+  **rofi** options that can be passed directly on the commandline (there are too many).
   Small snippets can be passed on the commandline: `rofi -theme-str 'window {width: 50%;}'` to override a single
-  setting. The are merged into the current theme.
-  They can also be appened at the end of the **rofi** config file to override parts of the theme.
+  setting. They are merged into the current theme.
+  They can also be appended at the end of the **rofi** config file to override parts of the theme.
 
 Most of the following options are **deprecated** and should not be used. Please use the new theme format to customize
 **rofi**. More information about the new format can be found in the **rofi-theme(5)** manpage.
@@ -750,7 +750,7 @@ This way it can be used as a drop-in replacement for dmenu. Just copy or symlink
 
 ## THEMING
 
-Please see **rofi-theme(5)** manpage for more information on themeing.
+Please see **rofi-theme(5)** manpage for more information on theming.
 
 ## KEY BINDINGS
 


### PR DESCRIPTION
This pull request amends an assortment of minor typos in the deprecation notice in the rofi.1 (and corresponding rofi.1.markdown) documentation pages.