### PR TITLE
[WIP] Mode specific xrm options

### DIFF
--- a/include/mode-private.h
+++ b/include/mode-private.h
@@ -28,6 +28,7 @@
 #ifndef ROFI_MODE_PRIVATE_H
 #define ROFI_MODE_PRIVATE_H
 #include <gmodule.h>
+#include "xrmoptions.h"
 G_BEGIN_DECLS
 
 /** ABI version to check if loaded plugin is compatible. */
@@ -195,6 +196,10 @@ struct rofi_mode
 
     /** Module */
     GModule    *module;
+
+    unsigned int num_options;
+
+    XrmOption   *xrm_options;
 };
 G_END_DECLS
 #endif // ROFI_MODE_PRIVATE_H

--- a/include/mode.h
+++ b/include/mode.h
@@ -29,6 +29,7 @@
 #define ROFI_MODE_H
 #include <cairo.h>
 #include "rofi-types.h"
+#include "xrmoptions.h"
 G_BEGIN_DECLS
 /**
  * @defgroup MODE Mode
@@ -147,6 +148,8 @@ cairo_surface_t * mode_get_icon ( const Mode *mode, unsigned int selected_line, 
  * @returns allocated string.
  */
 char * mode_get_completion ( const Mode *mode, unsigned int selected_line );
+
+XrmOption * mode_get_options ( const Mode *mode, unsigned int *num_options );
 
 /**
  * @param mode The mode to query

--- a/include/rofi.h
+++ b/include/rofi.h
@@ -63,6 +63,8 @@ unsigned int rofi_get_num_enabled_modi ( void );
  */
 const Mode * rofi_get_mode ( unsigned int index );
 
+const Mode * rofi_find_available_mode ( const char *name );
+
 /**
  * @param str A GString with an error message to display.
  *

--- a/include/xrmoptions.h
+++ b/include/xrmoptions.h
@@ -63,6 +63,15 @@
  * @{
  */
 
+/** Enumerator of different sources of configuration. */
+enum ConfigSource
+{
+    CONFIG_DEFAULT    = 0,
+    CONFIG_FILE       = 1,
+    CONFIG_FILE_THEME = 2,
+    CONFIG_CMDLINE    = 3
+};
+
 /**
  *  Type of the config options.
  */
@@ -79,6 +88,23 @@ typedef enum
     /** Config option is a character */
     xrm_Char    = 4
 } XrmOptionType;
+
+typedef struct
+{
+    int        type;
+    const char * name;
+    union
+    {
+        unsigned int * num;
+        int          * snum;
+        char         ** str;
+        void         *pointer;
+        char         * charc;
+    }                 value;
+    char              *mem;
+    const char        *comment;
+    enum ConfigSource source;
+} XrmOption;
 
 /**
  * Parse commandline options.
@@ -139,6 +165,8 @@ char ** config_parser_return_display_help ( unsigned int *length );
  * @returns true when failed to set property.
  */
 gboolean config_parse_set_property ( const Property *p, char **error );
+
+gboolean config_mode_parse_set_property ( const Property *p, XrmOption *options, unsigned int num_options, char **error );
 
 /**
  * @param out The destination.

--- a/source/dialogs/filebrowser.c
+++ b/source/dialogs/filebrowser.c
@@ -82,6 +82,17 @@ typedef struct
     unsigned int array_length;
 } FileBrowserModePrivateData;
 
+struct
+{
+    char *directory;
+} file_browser_config = {
+    .directory = NULL,
+};
+
+static XrmOption xrm_options[] = {
+    { xrm_String, "directory", { .str = &file_browser_config.directory }, NULL, "", CONFIG_DEFAULT },
+};
+
 static void free_list ( FileBrowserModePrivateData *pd )
 {
     for ( unsigned int i = 0; i < pd->array_length; i++ ) {
@@ -197,11 +208,11 @@ static void get_file_browser (  Mode *sw )
 static void file_browser_mode_init_current_dir ( Mode *sw ) {
     FileBrowserModePrivateData *pd = (FileBrowserModePrivateData *) mode_get_private_data ( sw );
 
-    gboolean config_has_valid_dir = config.file_browser_directory != NULL
-        && g_file_test ( config.file_browser_directory, G_FILE_TEST_IS_DIR );
+    gboolean config_has_valid_dir = file_browser_config.directory != NULL
+        && g_file_test ( file_browser_config.directory, G_FILE_TEST_IS_DIR );
 
     if ( config_has_valid_dir ) {
-        pd->current_dir = g_file_new_for_path ( config.file_browser_directory );
+        pd->current_dir = g_file_new_for_path ( file_browser_config.directory );
     } else {
         char *current_dir = NULL;
         char *cache_file = g_build_filename ( cache_dir, FILEBROWSER_CACHE_FILE, NULL );
@@ -503,4 +514,6 @@ Mode file_browser_mode =
     ._preprocess_input  = NULL,
     .private_data       = NULL,
     .free               = NULL,
+    .xrm_options        = xrm_options,
+    .num_options        = sizeof ( xrm_options ) / sizeof ( XrmOption ),
 };

--- a/source/mode.c
+++ b/source/mode.c
@@ -94,6 +94,14 @@ char * mode_get_completion ( const Mode *mode, unsigned int selected_line )
     }
 }
 
+XrmOption * mode_get_options ( const Mode *mode, unsigned int *num_options ) {
+    g_assert ( mode != NULL );
+
+    *num_options = mode->num_options;
+
+    return mode->xrm_options;
+}
+
 ModeMode mode_result ( Mode *mode, int menu_retv, char **input, unsigned int selected_line )
 {
     if ( menu_retv & MENU_NEXT ) {

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -135,6 +135,16 @@ const Mode * rofi_get_mode ( unsigned int index )
     return modi[index];
 }
 
+const Mode * rofi_find_available_mode ( const char *name )
+{
+    for ( unsigned int i = 0; i < num_available_modi; i++ ) {
+        if ( strcmp ( mode_get_name ( available_modi[i] ), name ) == 0 ) {
+            return available_modi[i];
+        }
+    }
+    return NULL;
+}
+
 /**
  * @param name Name of the switcher to lookup.
  *

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -54,31 +54,6 @@ const char * const ConfigSourceStr[] = {
     "Rasi File",
     "Commandline",
 };
-/** Enumerator of different sources of configuration. */
-enum ConfigSource
-{
-    CONFIG_DEFAULT    = 0,
-    CONFIG_FILE       = 1,
-    CONFIG_FILE_THEME = 2,
-    CONFIG_CMDLINE    = 3
-};
-
-typedef struct
-{
-    int        type;
-    const char * name;
-    union
-    {
-        unsigned int * num;
-        int          * snum;
-        char         ** str;
-        void         *pointer;
-        char         * charc;
-    }                 value;
-    char              *mem;
-    const char        *comment;
-    enum ConfigSource source;
-} XrmOption;
 /**
  * Map X resource and commandline options to internal options
  * Currently supports string, boolean and number (signed and unsigned).
@@ -410,7 +385,7 @@ gboolean config_parse_set_property ( const Property *p, char **error )
 
     for ( GList *iter = g_list_first ( extra_parsed_options) ; iter != NULL; iter = g_list_next ( iter ) ) {
       if ( g_strcmp0(((Property *)(iter->data))->name, p->name ) == 0 ){
-        
+
         rofi_theme_property_free ( (Property *)(iter->data));
         iter->data = (void *)rofi_theme_property_copy ( p ) ;
         return TRUE;
@@ -418,6 +393,18 @@ gboolean config_parse_set_property ( const Property *p, char **error )
     }
     g_debug("Adding option: %s to backup list.", p->name);
     extra_parsed_options = g_list_append ( extra_parsed_options , rofi_theme_property_copy ( p ) );
+
+    return TRUE;
+}
+
+gboolean config_mode_parse_set_property ( const Property *p, XrmOption *options, unsigned int num_options, char **error ) {
+    for ( unsigned int i = 0; i < num_options; ++i ) {
+        XrmOption *op = &( options[i] );
+
+        if ( g_strcmp0 ( op->name, p->name ) == 0 ) {
+            return __config_parser_set_property ( op, p, error );
+        }
+    }
 
     return TRUE;
 }


### PR DESCRIPTION
This is an experimental draft of mode specific xrm options. The idea is that each mode is able to specify its own `XrmOption`s which we then use to parse nested configuration blocks like this one:

```css
configuration {
  /* Mode.name */
  file-browser {
    /* XrmOption.name */ 
    directory: "/tmp";
  }
}
```