### PR TITLE
[FileBrowser] Add option to group directories ahead of files.

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -1185,6 +1185,8 @@ configuration {
         *   \- "ctime" (change time)
         */
       sorting\-method: "name";
+      /** Group directories before files. */
+      directories\-first: true;
    }
 }
 

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -713,6 +713,8 @@ configuration {
         *   - "ctime" (change time)
         */
       sorting-method: "name";
+      /** Group directories before files. */
+      directories-first: true;
    }
 }
 ```

--- a/source/dialogs/filebrowser.c
+++ b/source/dialogs/filebrowser.c
@@ -107,9 +107,11 @@ struct
 {
     enum FBSortingMethod sorting_method;
     enum FBSortingTime   sorting_time;
+    gboolean             directories_first;
 } file_browser_config = {
-    .sorting_method = FB_SORT_NAME,
-    .sorting_time   = FB_MTIME,
+    .sorting_method    = FB_SORT_NAME,
+    .sorting_time      = FB_MTIME,
+    .directories_first = TRUE,
 };
 
 static void free_list ( FileBrowserModePrivateData *pd )
@@ -131,7 +133,7 @@ static gint compare_name ( gconstpointer a, gconstpointer b, G_GNUC_UNUSED gpoin
     FBFile *fa = (FBFile *) a;
     FBFile *fb = (FBFile *) b;
 
-    if ( fa->type != fb->type ) {
+    if ( file_browser_config.directories_first && fa->type != fb->type ) {
         return fa->type - fb->type;
     }
 
@@ -142,6 +144,10 @@ static gint compare_time ( gconstpointer a, gconstpointer b, G_GNUC_UNUSED gpoin
 {
     FBFile *fa = (FBFile *) a;
     FBFile *fb = (FBFile *) b;
+
+    if ( file_browser_config.directories_first && fa->type != fb->type ) {
+        return fa->type - fb->type;
+    }
 
     if ( fa->time < 0 ) {
         return -1;
@@ -331,6 +337,11 @@ static void file_browser_mode_init_config ( Mode *sw )
 
             msg = g_strdup_printf ( "\"%s\" is not a valid filebrowser sorting method", p->value.s );
         }
+    }
+
+    p = rofi_theme_find_property ( wid, P_BOOLEAN, "directories-first", TRUE );
+    if ( p != NULL && p->type == P_BOOLEAN ) {
+        file_browser_config.directories_first = p->value.b;
     }
 
     if ( found_error ) {


### PR DESCRIPTION
Adds a new config option `directories-first` that makes it possible to toggle grouping of directories before files. It is set to `true` by default.