### PR TITLE
fix typo

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -943,7 +943,7 @@ fzf sorting.
 \fB\fC\-max\-history\-size\fR \fInumber\fP
 
 .PP
-Maximum number of entries to store in history. Defaults to 25. (WARNING: can cause slowdowns when set to high)
+Maximum number of entries to store in history. Defaults to 25. (WARNING: can cause slowdowns when set too high)
 
 .SS Dmenu specific
 .PP

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -560,7 +560,7 @@ There are 2 sorting method:
 
 `-max-history-size` *number*
 
-Maximum number of entries to store in history. Defaults to 25. (WARNING: can cause slowdowns when set to high)
+Maximum number of entries to store in history. Defaults to 25. (WARNING: can cause slowdowns when set too high)
 
 ### Dmenu specific
 

--- a/doc/test_xr.txt
+++ b/doc/test_xr.txt
@@ -116,7 +116,7 @@ rofi.scroll-method:                  0
 ! rofi.color-active:
 ! "Color scheme window" Set from: Default
 ! rofi.color-window:
-! "Max history size (WARNING: can cause slowdowns when set to high)." Set from: Default
+! "Max history size (WARNING: can cause slowdowns when set too high)." Set from: Default
 ! rofi.max-history-size:               25
 ! "Hide the prefix mode prefix on the combi view." Set from: Default
 ! rofi.combi-hide-mode-prefix:         false

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -183,7 +183,7 @@ static XrmOption xrmOptions[] = {
     { xrm_String,  "theme",                     { .str   = &config.theme                                }, NULL,
       "New style theme file", CONFIG_DEFAULT },
     { xrm_Number,  "max-history-size",          { .num   = &config.max_history_size                     }, NULL,
-      "Max history size (WARNING: can cause slowdowns when set to high).", CONFIG_DEFAULT },
+      "Max history size (WARNING: can cause slowdowns when set too high).", CONFIG_DEFAULT },
     { xrm_Boolean, "combi-hide-mode-prefix",    { .snum  = &config.combi_hide_mode_prefix               }, NULL,
       "Hide the prefix mode prefix on the combi view.", CONFIG_DEFAULT },
     { xrm_Char,    "matching-negate-char",      { .charc = &config.matching_negate_char                 }, NULL,


### PR DESCRIPTION
I changed all iterations of this particular typo. Wasn't certain as to the source document that likely generates all others?