### PR TITLE
Fixed dead link on REDAME for rofi-themes manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For more up to date information, please see the manpages:
 
  * Manpages:
      * [rofi](doc/rofi.1.markdown)
-     * [rofi-theme](doc/rofi.5.markdown)
+     * [rofi-theme](doc/rofi-theme.5.markdown)
      * [rofi-script](doc/rofi-script.5.markdown)
      * [rofi-theme-selector](doc/rofi-theme-selector.1.markdown)
  * Discussion places:


### PR DESCRIPTION
I fixed a dead link in the readme for the rofi-themes manpage.
It was linked to `doc/rofi.5.markdown` (which doesnt exist) instead of `doc/rofi-themes.5.markdown`
