### PR TITLE
update bug report template to the new GitHub issue form format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,57 +1,65 @@
----
-name: Bug report
-about: rofi might be misbehaving
-labels: bug
+name: Bug Report
+description: Report a problem in Rofi
+labels: [bug]
 title: "[BUG] "
-assignees: ''
----
-:exclamation:
-First read the [guidelines](https://github.com/DaveDavenport/rofi/blob/next/.github/CONTRIBUTING.md)!
-This is not optional for any report/question. People must be able to understand the full context of the report when reading it, at any time.
-If you feel like you “just have a simple question”, please consider you’re wrong and still fill the full report.
-Any report missing these informations will be labeled as “Incomplete Report - Please follow the guidelines” and may not be answered in a timely fashion.
+body:
 
-If you are unsure, please use the
-[discussion](https://github.com/davatorium/rofi/discussions) forum first. It is
-easy to upgrade a question to an issue in github.
-:exclamation:
+  - type: markdown
+    attributes:
+      value: |
+        First read the [guidelines](https://github.com/DaveDavenport/rofi/blob/next/.github/CONTRIBUTING.md)! This is not optional for any report/question. People must be able to understand the full context of the report when reading it, at any time.
 
-## Version
+        If you feel like you “just have a simple question”, please consider you’re wrong and still fill the full report. Any report missing these informations will be labeled as “Incomplete Report - Please follow the guidelines” and may not be answered in a timely fashion.
 
-Output of `rofi -v`
+        If you are unsure, please use the [discussion](https://github.com/davatorium/rofi/discussions) forum first. It is easy to upgrade a question to an issue in github.
+
+        **Please do not submit reports related to wayland, see [here](https://github.com/DaveDavenport/rofi/wiki/Wayland) for more information.**
+
+  - type: input
+    attributes:
+      label: "Rofi version (rofi -v)"
+      placeholder: "Version: 1.6.0"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Configuration"
+      description: "Please use https://gist.github.com"
+      placeholder: "Gist URL"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Launch command"
+      placeholder: "rofi -show drun"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Step to reproduce"
+      placeholder: |
+        * Step 1
+        * Step 2
+        * ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Expected behavior"
+      description: "Describe the behavior you expect. May include logs, images, or videos."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Actual behavior"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Additional information"
+    validations:
+      required: false
 
 
-## Configuration
-
-Output of `rofi -help` (in a [gist](https://gist.github.com/), please paste the *full* output)
-
-
-## Launch Command
-
-`The commandline used to launch **rofi**`
-
-
-## Steps to reproduce
-
-- Step 1
-- Step 2
-
-
-## What behaviour you see
-
-- ...
-
-
-## What behaviour you expect to see
-
-- ...
-
-
-**Additional details:**
-- Include a link to your private config
-- Include screenshots/casts of your issue
-
-
-**Please do not submit reports related to wayland, see
-[here](https://github.com/DaveDavenport/rofi/wiki/Wayland) for more
-information.**


### PR DESCRIPTION
As discussed on the IRC channel with qball, here's the PR to use the new GitHub issue form feature. You can find an example of the form at https://github.com/dannycolin/gh-form-issue/issues/new?assignees=&labels=bug&template=bug_report.yaml&title=%5BBUG%5D+