### PR TITLE
[rofi-sensible-terminal] Use /bin/sh instead of /usr/bin/env bash

### DIFF
--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # This code is released in public domain by Han Boetes <han@mijncomputer.nl>
 # Updated by Dave Davenport <qball@gmpclient.org>


### PR DESCRIPTION
This script is fully POSIX-sh compatible, i.e. it's portable and can be run in any shell, not just bash. It's incorrect to assume that bash is available on every *nix system (it's not), but /bin/sh is.