### PR TITLE
Add support for setting tabs stops on textboxes

### DIFF
--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -216,6 +216,7 @@ The current theme format supports different types:
  * an orientation
  * a cursor
  * a list of keywords
+ * an array of values
  * an environment variable
  * Inherit
 
@@ -532,6 +533,13 @@ Specify the type of mouse cursor that is set when the mouse pointer is over the 
 
 A list starts with a '[' and ends with a ']'. The entries in the list are comma-separated.
 The `keyword` in the list refers to an widget name.
+
+## Array of values
+
+* Format: `{ value, value, ... }`
+
+An array starts with a '{' and ends with a '}'. The entries in the array are comma-separated.
+Currently, only the integer and distance types are supported as array values.
 
 ## Environment variable
 

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -451,6 +451,22 @@ style property.
 
 > When no unit is specified, pixels are assumed.
 
+
+## Tab Stops
+
+* Format: `{Integer}`
+* Format: `{Distance}`
+* Format: `{Distance} {Distance}`
+* Format: `{Distance} {Distance} {Distance}`
+* Format: `{Distance} {Distance} {Distance} {Distance}`
+
+You can specify location of up to four tab stops by their distance from the beginning of the line.
+Each distance must be greater than the previous one.
+The text appears to the right of the tab stop position (other alignments are not supported yet).
+
+If no unit is specified, pixels are assumed.
+
+
 ## Position
 
 Indicate a place on the window/monitor.
@@ -768,6 +784,7 @@ The following properties are currently supported:
 * **placeholder-color**: Color of the placeholder text.
 * **blink**:             Enable/Disable blinking on an input textbox (Boolean).
 * **markup**:            Force markup on, beware that only valid pango markup strings are shown.
+* **tab-stops**:         Set the tab stops.
 
 ### listview:
 * **columns**:         integer

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -452,21 +452,6 @@ style property.
 > When no unit is specified, pixels are assumed.
 
 
-## Tab Stops
-
-* Format: `{Integer}`
-* Format: `{Distance}`
-* Format: `{Distance} {Distance}`
-* Format: `{Distance} {Distance} {Distance}`
-* Format: `{Distance} {Distance} {Distance} {Distance}`
-
-You can specify location of up to four tab stops by their distance from the beginning of the line.
-Each distance must be greater than the previous one.
-The text appears to the right of the tab stop position (other alignments are not supported yet).
-
-If no unit is specified, pixels are assumed.
-
-
 ## Position
 
 Indicate a place on the window/monitor.
@@ -784,7 +769,10 @@ The following properties are currently supported:
 * **placeholder-color**: Color of the placeholder text.
 * **blink**:             Enable/Disable blinking on an input textbox (Boolean).
 * **markup**:            Force markup on, beware that only valid pango markup strings are shown.
-* **tab-stops**:         Set the tab stops.
+* **tab-stops**:         array of distances
+    Set the location of tab stops by their distance from the beginning of the line.
+    Each distance should be greater than the previous one.
+    The text appears to the right of the tab stop position (other alignments are not supported yet).
 
 ### listview:
 * **columns**:         integer

--- a/include/widgets/widget-internal.h
+++ b/include/widgets/widget-internal.h
@@ -30,14 +30,25 @@
 
 #include "theme.h"
 
-/** Default padding. */
-#define WIDGET_DEFAULT_PADDING 0
-/** macro for initializing the padding struction. */
+/** Macro for initializing the RofiDistance struct. */
+#define WIDGET_DISTANCE_INIT                                                   \
+  (RofiDistance){                                                              \
+    .base = {                                                                  \
+      .distance = 0,                                                           \
+      .type = ROFI_PU_PX,                                                      \
+      .modtype = ROFI_DISTANCE_MODIFIER_NONE,                                  \
+      .left = NULL,                                                            \
+      .right = NULL,                                                           \
+    },                                                                         \
+    .style = ROFI_HL_SOLID,                                                    \
+  }
+/* Macro for initializing the RofiPadding struct. */
 #define WIDGET_PADDING_INIT                                                    \
-  {                                                                            \
-    {WIDGET_DEFAULT_PADDING, ROFI_PU_PX, ROFI_DISTANCE_MODIFIER_NONE, NULL,    \
-     NULL},                                                                    \
-        ROFI_HL_SOLID                                                          \
+  (RofiPadding){                                                               \
+    .top = WIDGET_DISTANCE_INIT,                                               \
+    .right = WIDGET_DISTANCE_INIT,                                             \
+    .bottom = WIDGET_DISTANCE_INIT,                                            \
+    .left = WIDGET_DISTANCE_INIT,                                              \
   }
 
 /**

--- a/include/widgets/widget-internal.h
+++ b/include/widgets/widget-internal.h
@@ -29,6 +29,17 @@
 #define WIDGET_INTERNAL_H
 
 #include "theme.h"
+
+/** Default padding. */
+#define WIDGET_DEFAULT_PADDING 0
+/** macro for initializing the padding struction. */
+#define WIDGET_PADDING_INIT                                                    \
+  {                                                                            \
+    {WIDGET_DEFAULT_PADDING, ROFI_PU_PX, ROFI_DISTANCE_MODIFIER_NONE, NULL,    \
+     NULL},                                                                    \
+        ROFI_HL_SOLID                                                          \
+  }
+
 /**
  * Data structure holding the internal state of the Widget
  */

--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -164,23 +164,26 @@ static void textbox_initialize_font(textbox *tb) {
 }
 
 static void textbox_tab_stops(textbox *tb) {
-  RofiPadding def = WIDGET_PADDING_INIT;
-  RofiPadding pad = rofi_theme_get_padding(WIDGET(tb), "tab-stops", def);
+  GList *dists = rofi_theme_get_array_distance(WIDGET(tb), "tab-stops");
 
-  if (&pad != &def) {
-    PangoTabArray *tabs = pango_tab_array_new(4, TRUE);
-    RofiDistance distances[] = {pad.top, pad.right, pad.bottom, pad.left};
+  if (dists != NULL) {
+    PangoTabArray *tabs = pango_tab_array_new(g_list_length(dists), TRUE);
 
-    for (int i = 0, ppx = 0; i < 4; i++) {
-      int px = distance_get_pixel(distances[i], ROFI_ORIENTATION_HORIZONTAL);
+    int i = 0, ppx = 0;
+    for (const GList *iter = g_list_first(dists); iter != NULL; iter = g_list_next(iter), i++) {
+      const RofiDistance *dist = iter->data;
+
+      int px = distance_get_pixel(*dist, ROFI_ORIENTATION_HORIZONTAL);
       if (px <= ppx) {
-        break;
+        continue;
       }
       pango_tab_array_set_tab(tabs, i, PANGO_TAB_LEFT, px);
       ppx = px;
     }
     pango_layout_set_tabs(tb->layout, tabs);
+
     pango_tab_array_free(tabs);
+    g_list_free_full(dists, g_free);
   }
 }
 

--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -163,6 +163,27 @@ static void textbox_initialize_font(textbox *tb) {
   }
 }
 
+static void textbox_tab_stops(textbox *tb) {
+  RofiPadding def = WIDGET_PADDING_INIT;
+  RofiPadding pad = rofi_theme_get_padding(WIDGET(tb), "tab-stops", def);
+
+  if (&pad != &def) {
+    PangoTabArray *tabs = pango_tab_array_new(4, TRUE);
+    RofiDistance distances[] = {pad.top, pad.right, pad.bottom, pad.left};
+
+    for (int i = 0, ppx = 0; i < 4; i++) {
+      int px = distance_get_pixel(distances[i], ROFI_ORIENTATION_HORIZONTAL);
+      if (px <= ppx) {
+        break;
+      }
+      pango_tab_array_set_tab(tabs, i, PANGO_TAB_LEFT, px);
+      ppx = px;
+    }
+    pango_layout_set_tabs(tb->layout, tabs);
+    pango_tab_array_free(tabs);
+  }
+}
+
 textbox *textbox_create(widget *parent, WidgetType type, const char *name,
                         TextboxFlags flags, TextBoxFontType tbft,
                         const char *text, double xalign, double yalign) {
@@ -186,6 +207,7 @@ textbox *textbox_create(widget *parent, WidgetType type, const char *name,
   textbox_font(tb, tbft);
 
   textbox_initialize_font(tb);
+  textbox_tab_stops(tb);
 
   if ((tb->flags & TB_WRAP) == TB_WRAP) {
     pango_layout_set_wrap(tb->layout, PANGO_WRAP_WORD_CHAR);

--- a/source/widgets/widget.c
+++ b/source/widgets/widget.c
@@ -36,15 +36,10 @@ void widget_init(widget *wid, widget *parent, WidgetType type,
   wid->type = type;
   wid->parent = parent;
   wid->name = g_strdup(name);
-  wid->def_padding = (RofiPadding){WIDGET_PADDING_INIT, WIDGET_PADDING_INIT,
-                                   WIDGET_PADDING_INIT, WIDGET_PADDING_INIT};
-  wid->def_border = (RofiPadding){WIDGET_PADDING_INIT, WIDGET_PADDING_INIT,
-                                  WIDGET_PADDING_INIT, WIDGET_PADDING_INIT};
-  wid->def_border_radius =
-      (RofiPadding){WIDGET_PADDING_INIT, WIDGET_PADDING_INIT,
-                    WIDGET_PADDING_INIT, WIDGET_PADDING_INIT};
-  wid->def_margin = (RofiPadding){WIDGET_PADDING_INIT, WIDGET_PADDING_INIT,
-                                  WIDGET_PADDING_INIT, WIDGET_PADDING_INIT};
+  wid->def_padding = WIDGET_PADDING_INIT;
+  wid->def_border = WIDGET_PADDING_INIT;
+  wid->def_border_radius = WIDGET_PADDING_INIT;
+  wid->def_margin = WIDGET_PADDING_INIT;
 
   wid->padding = rofi_theme_get_padding(wid, "padding", wid->def_padding);
   wid->border = rofi_theme_get_padding(wid, "border", wid->def_border);

--- a/source/widgets/widget.c
+++ b/source/widgets/widget.c
@@ -31,16 +31,6 @@
 #include <glib.h>
 #include <math.h>
 
-/** Default padding. */
-#define WIDGET_DEFAULT_PADDING 0
-/** macro for initializing the padding struction. */
-#define WIDGET_PADDING_INIT                                                    \
-  {                                                                            \
-    {WIDGET_DEFAULT_PADDING, ROFI_PU_PX, ROFI_DISTANCE_MODIFIER_NONE, NULL,    \
-     NULL},                                                                    \
-        ROFI_HL_SOLID                                                          \
-  }
-
 void widget_init(widget *wid, widget *parent, WidgetType type,
                  const char *name) {
   wid->type = type;


### PR DESCRIPTION
This allows to emulate a multi-column layout inside the text boxes.

I’m not happy with using the Padding struct for this, but I didn’t find any sensible way how to handle property with multiple distance values. Moreover, the latest Pango release (1.50) added support for tab alignments other than left (right, center and decimal) which would allow even more interesting layouts.

**Example:**

```sh
rofi -modi combi -show combi -combi-modi drun,ssh -combi-display-format '{text}&#09;{mode}'
```

```css
element-text {
  tab-stops: 500px;
}
```

![rofi](https://user-images.githubusercontent.com/949228/150709276-d7559a80-4583-4b92-8039-0f0c68a92b01.png)


