### PR TITLE
[DMenu] Huge list speedups

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -153,4 +153,6 @@ Settings config = {
     /** steal focus */
     .steal_focus = FALSE,
     /** fallback icon */
-    .application_fallback_icon = NULL};
+    .application_fallback_icon = NULL,
+    /** refilter limit */
+    .refilter_timeout_limit = 8192};

--- a/doc/rofi-dmenu.5
+++ b/doc/rofi-dmenu.5
@@ -248,16 +248,6 @@ Note: the default asynchronous mode will also be automatically disabled if used 
 such as \fB\fC-dump\fR, \fB\fC-only-match\fR or \fB\fC-auto-select\fR\&.
 
 .PP
-\fB\fC-async-pre-read\fR \fInumber\fP
-
-.PP
-Reads the first \fInumber\fP entries blocking, then switches to async mode.
-This makes it feel more 'snappy'.
-
-.PP
-\fIdefault\fP: 25
-
-.PP
 \fB\fC-window-title\fR \fItitle\fP
 
 .PP

--- a/doc/rofi-dmenu.5.markdown
+++ b/doc/rofi-dmenu.5.markdown
@@ -158,13 +158,6 @@ Force **rofi** mode to first read all data from stdin before showing the selecti
 Note: the default asynchronous mode will also be automatically disabled if used with conflicting options,
 such as `-dump`, `-only-match` or `-auto-select`.
 
-`-async-pre-read` *number*
-
-Reads the first *number* entries blocking, then switches to async mode.
-This makes it feel more 'snappy'.
-
-*default*: 25
-
 `-window-title` *title*
 
 Set name used for the window title. Will be shown as Rofi - *title*

--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -455,6 +455,15 @@ Make \fBrofi\fP react like a normal application window. Useful for scripts like 
 .PP
 Make rofi steal focus on launch and restore close to window that held it when launched.
 
+.PP
+\fB\fC-refilter-timeout-limit\fR
+
+.PP
+The limit of elements that is used to switch from instant to delayed filter mode.
+
+.PP
+Default: 8192
+
 .SS Matching
 .PP
 \fB\fC-matching\fR \fImethod\fP

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -274,6 +274,12 @@ Make **rofi** react like a normal application window. Useful for scripts like Cl
 
 Make rofi steal focus on launch and restore close to window that held it when launched.
 
+`-refilter-timeout-limit`
+
+The limit of elements that is used to switch from instant to delayed filter mode.
+
+  Default: 8192
+
 ### Matching
 
 `-matching` *method*

--- a/include/settings.h
+++ b/include/settings.h
@@ -177,6 +177,10 @@ typedef struct {
   gboolean steal_focus;
   /** fallback icon */
   char *application_fallback_icon;
+
+  /** refilter timeout limit, when more then these entries,go into timeout mode.
+   */
+  unsigned int refilter_timeout_limit;
 } Settings;
 
 /** Default number of lines in the list view */

--- a/source/modes/dmenu.c
+++ b/source/modes/dmenu.c
@@ -192,12 +192,10 @@ static void read_input_sync(DmenuModePrivateData *pd, unsigned int pre_read) {
   ssize_t nread;
   size_t len = 0;
   char *line = NULL;
-  while ((nread = getdelim(&line, &len, pd->separator, pd->fd_file)) != -1) {
+  while (pre_read > 0 &&
+         (nread = getdelim(&line, &len, pd->separator, pd->fd_file)) != -1) {
     read_add(pd, line, len);
     pre_read--;
-    if (pre_read == 0) {
-      break;
-    }
   }
   free(line);
   return;

--- a/source/view.c
+++ b/source/view.c
@@ -1241,7 +1241,6 @@ static gboolean rofi_view_refilter_real(RofiViewState *state) {
 static void rofi_view_refilter(RofiViewState *state) {
   CacheState.refilter_timeout_count++;
   if (CacheState.refilter_timeout != 0) {
-    printf("timeout reset\n");
 
     g_source_remove(CacheState.refilter_timeout);
     CacheState.refilter_timeout = 0;

--- a/source/view.c
+++ b/source/view.c
@@ -1246,7 +1246,8 @@ static void rofi_view_refilter(RofiViewState *state) {
     g_source_remove(CacheState.refilter_timeout);
     CacheState.refilter_timeout = 0;
   }
-  if (CacheState.refilter_timeout_count < 25 && state->text &&
+  if (state->num_lines > config.refilter_timeout_limit &&
+      CacheState.refilter_timeout_count < 25 && state->text &&
       strlen(state->text->text) > 0) {
     CacheState.refilter_timeout =
         g_timeout_add(200, (GSourceFunc)rofi_view_refilter_real, state);

--- a/source/view.c
+++ b/source/view.c
@@ -1146,6 +1146,9 @@ static gboolean rofi_view_refilter_real(RofiViewState *state) {
      * speedup of the whole function.
      */
     unsigned int nt = MAX(1, state->num_lines / 500);
+    // Limit the number of jobs, it could cause stack overflow if we don´t
+    // limit.
+    nt = MIN(nt, config.threads * 4);
     thread_state_view states[nt];
     GCond cond;
     GMutex mutex;

--- a/source/view.c
+++ b/source/view.c
@@ -1254,6 +1254,15 @@ static void rofi_view_refilter(RofiViewState *state) {
     rofi_view_refilter_real(state);
   }
 }
+static void rofi_view_refilter_force(RofiViewState *state) {
+  if (CacheState.refilter_timeout != 0) {
+    g_source_remove(CacheState.refilter_timeout);
+    CacheState.refilter_timeout = 0;
+  }
+  if (state->refilter) {
+    rofi_view_refilter_real(state);
+  }
+}
 /**
  * @param state The Menu Handle
  *
@@ -1466,6 +1475,7 @@ static void rofi_view_trigger_global_action(KeyBindingAction action) {
     break;
   }
   case ACCEPT_ALT: {
+    rofi_view_refilter_force(state);
     unsigned int selected = listview_get_selected(state->list_view);
     state->selected_line = UINT32_MAX;
     if (selected < state->filtered_lines) {
@@ -1480,18 +1490,21 @@ static void rofi_view_trigger_global_action(KeyBindingAction action) {
     break;
   }
   case ACCEPT_CUSTOM: {
+    rofi_view_refilter_force(state);
     state->selected_line = UINT32_MAX;
     state->retv = MENU_CUSTOM_INPUT;
     state->quit = TRUE;
     break;
   }
   case ACCEPT_CUSTOM_ALT: {
+    rofi_view_refilter_force(state);
     state->selected_line = UINT32_MAX;
     state->retv = MENU_CUSTOM_INPUT | MENU_CUSTOM_ACTION;
     state->quit = TRUE;
     break;
   }
   case ACCEPT_ENTRY: {
+    rofi_view_refilter_force(state);
     // If a valid item is selected, return that..
     unsigned int selected = listview_get_selected(state->list_view);
     state->selected_line = UINT32_MAX;

--- a/source/widgets/scrollbar.c
+++ b/source/widgets/scrollbar.c
@@ -161,9 +161,9 @@ void scrollbar_set_handle_length(scrollbar *sb, unsigned int pos_length) {
  */
 static void scrollbar_draw(widget *wid, cairo_t *draw) {
   scrollbar *sb = (scrollbar *)wid;
-  unsigned int wh = widget_padding_get_remaining_height(wid);
+  double wh = widget_padding_get_remaining_height(wid);
   // Calculate position and size.
-  unsigned int r = (sb->length * wh) / ((double)(sb->length + sb->pos_length));
+  double r = (sb->length * wh) / ((double)(sb->length + sb->pos_length));
   unsigned int handle = wid->h - r;
   double sec = ((r) / (double)(sb->length - 1));
   unsigned int height = handle;

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -424,6 +424,13 @@ static XrmOption xrmOptions[] = {
      NULL,
      "Fallback icon to use when the application icon is not found in run/drun.",
      CONFIG_DEFAULT},
+    {xrm_Number,
+     "refilter-timeout-limit",
+     {.num = &(config.refilter_timeout_limit)},
+     NULL,
+     "When there are more entries then this limit, only refilter after a "
+     "timeout.",
+     CONFIG_DEFAULT},
 };
 
 /** Dynamic array of extra options */


### PR DESCRIPTION
Two major changes:

1. Rewrite input reading in dmenu. Instead of using the slow GIOChannel, we now have a custom (yay) implementation that uses a separate reading threads, and block-wise signaling of the main thread. This improves the async reading speed significantly.
2. On large lists (by default > 8192) put a small delay between last key-press and filtering. This tries to reduce the number of refilters when typing int he query.


