### PR TITLE
[filebrowser] Fix st_atim undefined on macOS

### DIFF
--- a/source/modes/filebrowser.c
+++ b/source/modes/filebrowser.c
@@ -50,6 +50,12 @@
 
 #define FILEBROWSER_CACHE_FILE "rofi3.filebrowsercache"
 
+#if defined(__APPLE__)
+#define st_atim st_atimespec
+#define st_ctim st_ctimespec
+#define st_mtim st_mtimespec
+#endif
+
 /**
  * The internal data structure holding the private data of the TEST Mode.
  */


### PR DESCRIPTION
When compiling on macOS, an error message will pop up:

```
error: no member named 'st_atim' in 'struct stat'
```

This is because `st_atim`, `st_ctim` and `st_mtim` does not exist on
macOS, instead it uses `st_atimespec`, `st_ctimespec` and
`st_mtimespec`.

In this commit, 3 macros are defined to try to fix this problem.

Reference: https://github.com/hboetes/mg/issues/7