### PR TITLE
Add installation instructions for macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -217,3 +217,9 @@ On both openSUSE Leap and openSUSE Tumbleweed rofi can be installed using:
 ### FreeBSD
 
     sudo pkg install rofi
+
+### macOS
+
+On macOS rofi can be installed via [MacPorts](https://www.macports.org):
+
+    sudo port install rofi


### PR DESCRIPTION
A new port has been added in https://github.com/macports/macports-ports/pull/15503

Now macOS users can install rofi via MacPorts.
