### PR TITLE
Fix manual for centering text relative to icon

### DIFF
--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -116,7 +116,7 @@ list of widget names.
 If you want to center the text relative to the icon, we can set this:
 
 ```css
-element-icon {
+element-text {
     vertical-align: 0.5;
 }
 ```


### PR DESCRIPTION
Centering text relative to the icon should apply `vertical-align` to `element-text` not on `element-icon`.