### PR TITLE
Include sys/stat.h for S_IWUSR

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -41,6 +41,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <xcb/xcb.h>
+#include <sys/stat.h>
 
 #include <glib-unix.h>
 


### PR DESCRIPTION
Explicitly include `sys/stat.h` to be able to get to `S_IWUSR`. This is required on OpenBSD.