### PR TITLE
[Themes] Fix and restore Pop-Dark

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -202,6 +202,7 @@ theme_DATA=\
 		   themes/Arc.rasi\
 		   themes/Arc-Dark.rasi\
 		   themes/DarkBlue.rasi\
+		   themes/Pop-Dark.rasi\
 		   themes/Indego.rasi\
 		   themes/Monokai.rasi\
 		   themes/Paper.rasi\

--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,7 @@ install_data(
     'themes/Arc.rasi',
     'themes/Arc-Dark.rasi',
     'themes/DarkBlue.rasi',
+    'themes/Pop-Dark.rasi',
     'themes/Indego.rasi',
     'themes/Monokai.rasi',
     'themes/Paper.rasi',

--- a/themes/Pop-Dark.rasi
+++ b/themes/Pop-Dark.rasi
@@ -1,0 +1,129 @@
+/**
+ * Author: Primetoxinz
+ */
+* {
+    text-color:                  #f2f2f2;
+    background-color:            #4e4743;
+    lightbg:                     #534c48;
+    red:                         #f15d22;
+    orange:                      #faa41a; 
+    blue:                        #48b9c7; 
+
+    background:                  @background-color;
+    foreground:                  @text-color;
+
+    selected-normal-foreground:  @foreground;
+    normal-foreground:           @foreground;
+    alternate-normal-background: @background;
+    selected-urgent-foreground:  @foreground;
+    urgent-foreground:           @foreground;
+    alternate-urgent-background: @background;
+    active-foreground:           @foreground;
+    selected-active-foreground:  @foreground;
+    alternate-normal-foreground: @foreground;
+    alternate-active-background: @blue;
+    bordercolor:                 @foreground;
+    normal-background:           @background;
+    selected-normal-background:  @blue;
+    separatorcolor:              @orange;
+    spacing:                     2;
+    urgent-background:           @red;
+    alternate-urgent-foreground: @foreground;
+    selected-urgent-background:  @red;
+    alternate-active-foreground: @foreground;
+    selected-active-background:  @blue;
+    active-background:           @orange;
+}
+window {
+    border:     0;
+    text-color: @foreground;
+    background-color: rgba ( 0, 0, 0, 0 % );
+    padding:    5;
+    text-color: @bordercolor;
+    background-color: @background;
+}
+mainbox {
+    border:  0;
+    padding: 0;
+}
+message {
+    border:     1px dash 0px 0px ;
+    text-color: @separatorcolor;
+    padding:    2px 0px 0px ;
+}
+textbox {
+    text-color: @foreground;
+}
+listview {
+    fixed-height: 0;
+    border:       2px 0px 0px ;
+    padding:      2px 0px 0px ;
+    text-color: @separatorcolor;
+}
+element {
+    border: 0;
+}
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
+}
+element.normal.normal {
+    text-color: @normal-foreground;
+    background-color: @normal-background;
+}
+element.normal.urgent {
+    text-color: @urgent-foreground;
+    background-color: @urgent-background;
+}
+element.normal.active {
+    text-color: @active-foreground;
+    background-color: @active-background;
+}
+element.selected.normal {
+    text-color: @selected-normal-foreground;
+    background-color: @selected-normal-background;
+}
+element.selected.urgent {
+    text-color: @selected-urgent-foreground;
+    background-color: @selected-urgent-background;
+}
+element.selected.active {
+    text-color: @selected-active-foreground;
+    background-color: @selected-active-background;
+}
+element.alternate.normal {
+    text-color: @alternate-normal-foreground;
+    background-color: @alternate-normal-background;
+}
+element.alternate.urgent {
+    text-color: @alternate-urgent-foreground;
+    background-color: @alternate-urgent-background;
+}
+element.alternate.active {
+    text-color: @alternate-active-foreground;
+    background-color: @alternate-active-background;
+}
+mode-switcher {
+    border: 1px dash 0px 0px ;
+}
+button selected {
+    text-color: @selected-normal-foreground;
+    background-color: @selected-normal-background;
+}
+inputbar {
+    spacing: 0;
+    border: 0px ;
+}
+button normal {
+    text-color: @foreground;
+}
+
+inputbar {
+    children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
+}
+textbox-prompt-colon {
+    expand:     false;
+    str:        ":";
+    margin:     0px 0.3em 0em 0em ;
+    text-color: @normal-foreground;
+}


### PR DESCRIPTION
This PR somewhat reverts https://github.com/davatorium/rofi/commit/c0feb2eb0ddfef7f31e179e9585543b1d746cf1c, by restoring `Pop-Dark` and fixing the two missing variables on it.

From the context I understand that the `var(something)` syntax is now preferred to `@something`. If you want, I can probably hack some regex to fix that on the theme too.