### PR TITLE
[DOC] Add parsing row options to dmenu manpage

### DIFF
--- a/doc/rofi-dmenu.5.markdown
+++ b/doc/rofi-dmenu.5.markdown
@@ -192,6 +192,10 @@ When multi-select is enabled, prefix this string when element is not selected.
 
 *default*: "☐ "
 
+## PARSING ROW OPTIONS
+
+Extra options for individual rows can be also set. See the **rofi-script(5)** manpage for details; the syntax and supported features are identical.
+
 ## RETURN VALUE
 
  * **0**: Row has been selected accepted by user.


### PR DESCRIPTION
As discussed in https://github.com/davatorium/rofi/discussions/1729, I have added a hint to the `rofi-dmenu` manpage about row parsing options, referring the reader to the `rofi-script` manpage.
