### PR TITLE
[WIP] Ellipsize modes

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -106,6 +106,7 @@ Settings config = {
     .tokenize = TRUE,
     .matching = "normal",
     .matching_method = MM_NORMAL,
+    .ellipsize_mode = "end",
 
     /** Desktop entries to match in drun */
     .drun_match_fields = "name,generic,exec,categories,keywords",

--- a/include/settings.h
+++ b/include/settings.h
@@ -98,6 +98,8 @@ typedef struct {
   SortingMethod sorting_method_enum;
   /** Sorting method. */
   char *sorting_method;
+  /** How to ellipsize an entry */
+  char *ellipsize_mode;
 
   /** Desktop entries to match in drun */
   char *drun_match_fields;

--- a/include/view.h
+++ b/include/view.h
@@ -338,9 +338,21 @@ void rofi_capture_screenshot(void);
 void rofi_view_set_window_title(const char *title);
 
 /**
- * set ellipsize mode to start.
+ * Set ellipsize mode to start.
  */
 void rofi_view_ellipsize_start(RofiViewState *state);
+
+/**
+ * Set ellipsize mode to middle.
+ */
+void rofi_view_ellipsize_middle(RofiViewState *state);
+/** @} */
+
+/**
+ * Set ellipsize mode to end.
+ */
+void rofi_view_ellipsize_end(RofiViewState *state);
+/** @} */
 
 /**
  * @param new_x New XIM window x pos

--- a/include/view.h
+++ b/include/view.h
@@ -346,13 +346,11 @@ void rofi_view_ellipsize_start(RofiViewState *state);
  * Set ellipsize mode to middle.
  */
 void rofi_view_ellipsize_middle(RofiViewState *state);
-/** @} */
 
 /**
  * Set ellipsize mode to end.
  */
 void rofi_view_ellipsize_end(RofiViewState *state);
-/** @} */
 
 /**
  * @param new_x New XIM window x pos

--- a/include/widgets/listview.h
+++ b/include/widgets/listview.h
@@ -280,6 +280,22 @@ void listview_set_ellipsize_start(listview *lv);
 
 /**
  * @param lv Handler to the listview object.
+ *
+ * Set ellipsize mode to middle.
+ */
+
+void listview_set_ellipsize_middle(listview *lv);
+
+/**
+ * @param lv Handler to the listview object.
+ *
+ * Set ellipsize mode to end.
+ */
+
+void listview_set_ellipsize_end(listview *lv);
+
+/**
+ * @param lv Handler to the listview object.
  * @param filtered boolean indicating if list is filtered.
  *
  */

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -181,6 +181,7 @@ static void teardown(int pfd) {
   // Cleanup pid file.
   remove_pid_file(pfd);
 }
+static void help_print_invalid_ellipsize(const char*);
 static void run_mode_index(ModeMode mode) {
   // Otherwise check if requested mode is enabled.
   for (unsigned int i = 0; i < num_modes; i++) {
@@ -207,6 +208,20 @@ static void run_mode_index(ModeMode mode) {
     unsigned int sr = 0;
     find_arg_uint("-selected-row", &(sr));
     rofi_view_set_selected_line(state, sr);
+  }
+
+  // Ellipsize mode selection
+  char *ellipsize_mode = NULL;
+  if (find_arg_str("-ellipsize-mode", &ellipsize_mode) == TRUE) { // ellipsize key has a value
+    if (strcmp(ellipsize_mode, "start") == 0) { // start ellipsis
+      rofi_view_ellipsize_start(state);
+    } else if (strcmp(ellipsize_mode, "middle") == 0) { // middle ellipsis
+      rofi_view_ellipsize_middle(state);
+    } else if (strcmp(ellipsize_mode, "end") == 0) { // end ellipsis
+      rofi_view_ellipsize_end(state);
+    } else { // invalid mode given, do nothing (use default)
+	  help_print_invalid_ellipsize(ellipsize_mode);
+    }
   }
   if (state) {
     rofi_view_set_active(state);
@@ -476,6 +491,16 @@ static void help_print_no_arguments(void) {
                          "setting.\n");
   rofi_view_error_dialog(emesg->str, ERROR_MSG_MARKUP);
   rofi_set_return_code(EXIT_SUCCESS);
+}
+
+static void help_print_invalid_ellipsize(const char *mode) {
+  int is_term = isatty(fileno(stdout));
+  if (is_term) { // Color output if terminal
+    fprintf(stderr, "Ellipsize mode %s%s%s does not exist.\n",
+            color_red, mode, color_reset);
+  } else { // Otherwise regular output
+    fprintf(stderr, "Ellipsize mode %s does not exist.\n", mode);
+  }
 }
 
 /**

--- a/source/view.c
+++ b/source/view.c
@@ -2500,7 +2500,27 @@ void rofi_view_clear_input(RofiViewState *state) {
 }
 
 void rofi_view_ellipsize_start(RofiViewState *state) {
+  if (state == NULL) {
+    return;
+  }
+
   listview_set_ellipsize_start(state->list_view);
+}
+
+void rofi_view_ellipsize_middle(RofiViewState *state) {
+  if (state == NULL) {
+    return;
+  }
+
+  listview_set_ellipsize_middle(state->list_view);
+}
+
+void rofi_view_ellipsize_end(RofiViewState *state) {
+  if (state == NULL) {
+    return;
+  }
+
+  listview_set_ellipsize_end(state->list_view);
 }
 
 void rofi_view_switch_mode(RofiViewState *state, Mode *mode) {

--- a/source/widgets/listview.c
+++ b/source/widgets/listview.c
@@ -1113,6 +1113,24 @@ void listview_set_ellipsize_start(listview *lv) {
   }
 }
 
+void listview_set_ellipsize_middle(listview *lv) {
+  if (lv) {
+    lv->emode = PANGO_ELLIPSIZE_MIDDLE;
+    for (unsigned int i = 0; i < lv->cur_elements; i++) {
+      textbox_set_ellipsize(lv->boxes[i].textbox, lv->emode);
+    }
+  }
+}
+
+void listview_set_ellipsize_end(listview *lv) {
+  if (lv) {
+    lv->emode = PANGO_ELLIPSIZE_END;
+    for (unsigned int i = 0; i < lv->cur_elements; i++) {
+      textbox_set_ellipsize(lv->boxes[i].textbox, lv->emode);
+    }
+  }
+}
+
 void listview_toggle_ellipsizing(listview *lv) {
   if (lv) {
     PangoEllipsizeMode mode = lv->emode;

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -121,6 +121,12 @@ static XrmOption xrmOptions[] = {
      NULL,
      "Always show number of lines",
      CONFIG_DEFAULT},
+    {xrm_String,
+     "ellipsize-mode",
+     {.str = &config.ellipsize_mode},
+     NULL,
+     "How to ellipsize entries",
+     CONFIG_DEFAULT},
 
     {xrm_Boolean,
      "show-icons",


### PR DESCRIPTION
This PR creates additional functions for setting ellipsize mode; to middle and end along with the already existing start function, and adds command line options to control the initial ellipsize mode: `-ellipsize-mode (start|middle|end)`.

Some things though:
* Is this the right place to implement this?
* How should I give an error? Right now, I'm following how -scroll-method does it, and just reverting to default if invalid, and printing out an error message to stderr, but I'm not sure if this is the right way to print out an error message, especially since I had to forward-declare the error printing function.
* Is the option (-ellipsize-mode) too long?
* This (currently) doesn't apply to the dmenu mode, should I duplicate this code into dmenu_mode_dialog() or is there a better way.

Thanks :)