### PR TITLE
[DOC] Add example run command with cgroup support

### DIFF
--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -902,6 +902,18 @@ See \fIPATTERN\fP\&.
 Default: \fI{cmd}\fP
 
 .PP
+Example to run applications in a dedicated cgroup with systemd. Requires a shell to escape and interpolate the unit name correctly.
+
+.PP
+.RS
+
+.nf
+"bash -c 'systemd-run --user --unit=app-rofi-\\$(systemd-escape {cmd})-\\$RANDOM {cmd}'"
+
+.fi
+.RE
+
+.PP
 \fB\fC-run-shell-command\fR \fIcmd\fP
 
 .PP

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -543,6 +543,12 @@ See *PATTERN*.
 
 Default: *{cmd}*
 
+Example to run applications in a dedicated cgroup with systemd. Requires a shell to escape and interpolate the unit name correctly.
+
+```
+"bash -c 'systemd-run --user --unit=app-rofi-\$(systemd-escape {cmd})-\$RANDOM {cmd}'"
+```
+
 `-run-shell-command` *cmd*
 
 Set command to execute when running an application in a shell.


### PR DESCRIPTION
Adds an example command to launch processes via systemd-run into a dedicated systemd scope within the users slice, which allows using systemd-oomd, that evaluates memory consumption on a per cgroup basis.

Related to #1751 
