### PR TITLE
make cursor more customizable by adding cursor-width and cursor-color

### DIFF
--- a/doc/rofi-theme.5
+++ b/doc/rofi-theme.5
@@ -197,6 +197,25 @@ element-text {
 .RE
 
 .PP
+We can also specify the color and width of the cursor. You could, for example,
+create a crimson block cursor like this:
+
+.PP
+.RS
+
+.nf
+entry {
+  cursor-color: rgb(220,20,60);
+  cursor-width: 8px;
+}
+
+.fi
+.RE
+
+.PP
+By default, the \fB\fCcursor-color\fR will be the same as the \fB\fCtext-color\fR\&. The \fB\fCcursor-width\fR will always default to 2 pixels.
+
+.PP
 If you want to see the complete theme, including the modification you can run:
 
 .PP

--- a/doc/rofi-theme.5
+++ b/doc/rofi-theme.5
@@ -1532,6 +1532,10 @@ This option is only available on the \fB\fCelement-text\fR widget.
 Set the location of tab stops by their distance from the beginning of the line.
 Each distance should be greater than the previous one.
 The text appears to the right of the tab stop position (other alignments are not supported yet).
+.IP \(bu 2
+\fBcursor-width\fP:      The width of the cursor.
+.IP \(bu 2
+\fBcursor-color\fP:      The color used to draw the cursor.
 
 .RE
 

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -132,6 +132,18 @@ element-text {
 └─────────────────────────────────────────────────────────────────────┘ 
 ```
 
+We can also specify the color and width of the cursor. You could, for example,
+create a crimson block cursor like this:
+
+```css
+entry {
+  cursor-color: rgb(220,20,60);
+  cursor-width: 8px;
+}
+```
+
+By default, the `cursor-color` will be the same as the `text-color`. The `cursor-width` will always default to 2 pixels.
+
 If you want to see the complete theme, including the modification you can run:
 
 ```bash

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -949,6 +949,8 @@ The following properties are currently supported:
     Set the location of tab stops by their distance from the beginning of the line.
     Each distance should be greater than the previous one.
     The text appears to the right of the tab stop position (other alignments are not supported yet).
+* **cursor-width**:      The width of the cursor.
+* **cursor-color**:      The color used to draw the cursor.
 
 ### listview:
 * **columns**:         integer

--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -482,9 +482,12 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
   }
   y += top;
 
-  if (tb->show_placeholder) {
-    rofi_theme_get_color(WIDGET(tb), "placeholder-color", draw);
-  }
+  // TODO check if this is still needed after flatning.
+  cairo_set_operator(draw, CAIRO_OPERATOR_OVER);
+  cairo_set_source_rgb ( draw, 0.0, 0.0, 0.0 );
+  // use text color as fallback for themes that don't specify the cursor color
+  rofi_theme_get_color(WIDGET(tb), "text-color", draw);
+
   // Set ARGB
   // We need to set over, otherwise subpixel hinting wont work.
   switch (pango_layout_get_alignment(tb->layout)) {
@@ -514,12 +517,6 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
     break;
   }
   }
-
-  // TODO check if this is still needed after flatning.
-  cairo_set_operator(draw, CAIRO_OPERATOR_OVER);
-  cairo_set_source_rgb ( draw, 0.0, 0.0, 0.0 );
-  // use text color as fallback for themes that don't specify the cursor color
-  rofi_theme_get_color(WIDGET(tb), "text-color", draw);
 
   // draw the cursor
   if (tb->flags & TB_EDITABLE) {
@@ -553,6 +550,9 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
   // draw the text
   cairo_save(draw);
   cairo_reset_clip(draw);
+  if (tb->show_placeholder) {
+    rofi_theme_get_color(WIDGET(tb), "placeholder-color", draw);
+  }
   pango_cairo_show_layout(draw, tb->layout);
   cairo_restore(draw);
 }


### PR DESCRIPTION
This pull request aims to make cursor more customizable by adding `cursor-width` and `cursor-color` to the theme. This will allow the creation of block cursors such as this:
![block_cursor](https://user-images.githubusercontent.com/24727270/192270313-37f5680b-18bc-4378-9909-6147d1ad1283.jpg)
and also address issue #788.