### PR TITLE
[WIP] Improve require-input user experience

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Deiwin Sarjas
 Dimitar Yordanov
 Edwin Pujols
 eigengrau
+Enrico Lamperti
 Eric Engeström
 Fangrui Song
 fice-t

--- a/doc/rofi-theme.5
+++ b/doc/rofi-theme.5
@@ -1579,8 +1579,7 @@ The order the elements are layed out.  Vertical is the original 'column' view.
 Do not reduce the number of columns shown when number of visible elements is not enough to fill them all.
 .IP \(bu 2
 \fBrequire-input\fP:    boolean
-Listview requires user input to be unhidden. The list will still respond to normal interaction.
-Hitting accept will still activate the selected entry.
+Listview requires user input to be unhidden. Hitting accept with no input won't activate any entry.
 
 .RE
 

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -978,8 +978,7 @@ The following properties are currently supported:
 * **fixed-columns**:    boolean
     Do not reduce the number of columns shown when number of visible elements is not enough to fill them all.
 * **require-input**:    boolean
-    Listview requires user input to be unhidden. The list will still respond to normal interaction.
-    Hitting accept will still activate the selected entry.
+    Listview requires user input to be unhidden. Hitting accept with no input won't activate any entry.
 
 Each element is a `box` called `element`. Each `element` can contain an `element-icon` and `element-text`.
 

--- a/source/view.c
+++ b/source/view.c
@@ -1717,7 +1717,7 @@ static void rofi_view_trigger_global_action(KeyBindingAction action) {
   }
   case ACCEPT_ENTRY: {
     rofi_view_refilter_force(state);
-    // If a valid item is selected, return that..
+    // If a valid item is selected, return that.
     unsigned int selected = listview_get_selected(state->list_view);
     state->selected_line = UINT32_MAX;
     if (selected < state->filtered_lines) {
@@ -1728,7 +1728,9 @@ static void rofi_view_trigger_global_action(KeyBindingAction action) {
       state->retv = MENU_CUSTOM_INPUT;
     }
 
-    state->quit = TRUE;
+    if (selected != UINT32_MAX) {
+      state->quit = TRUE;
+    }
     break;
   }
   }

--- a/source/widgets/listview.c
+++ b/source/widgets/listview.c
@@ -577,6 +577,9 @@ void listview_set_num_elements(listview *lv, unsigned int rows) {
 }
 
 unsigned int listview_get_selected(listview *lv) {
+  if (lv->require_input && !lv->filtered) {
+    return UINT32_MAX;
+  }
   if (lv != NULL) {
     return lv->selected;
   }


### PR DESCRIPTION
Whenever the listview has `require-input` set to true, if the user hasn't entered any text, pressing kb-accept will result in the selection of the first item of the list, even if it's not visible for the user.  Also trying to navigate the list (blindly) doesn't change the selected item either.

My proposed change prevents auto-selecting the first option blindly, avoiding an unexpected default selection (whatever is the first item in the listview). With this change, rofi remains open until the user either enters the _required input_ and accepts, or presses kb-cancel. This goes in line with the UX of other search/filtering tools, and it should benefit the community users' who use this option.

See more details and ongoing discussion [here](https://github.com/davatorium/rofi/discussions/1763).
