### PR TITLE
[CI] Maintenance.

### DIFF
--- a/.github/actions/autotools/action.yml
+++ b/.github/actions/autotools/action.yml
@@ -30,7 +30,7 @@ runs:
       run: cd builddir && make distcheck
       shell: bash
     - id: doxy
-      run: cd builddir && make doxy 2>&1 > doxygen.log
+      run: cd builddir && make doxy > doxygen.log 2>&1
       shell: bash
     - id: doxycheck
       uses: ./.github/actions/doxycheck

--- a/.github/actions/autotools/action.yml
+++ b/.github/actions/autotools/action.yml
@@ -45,7 +45,7 @@ runs:
         make 
         make check
     - id: upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tarballs
         path: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - id: python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - id: apt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   build-meson-gcc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup
@@ -28,7 +28,7 @@ jobs:
   build-meson-clang:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup
@@ -38,7 +38,7 @@ jobs:
   build-autotools-gcc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup
@@ -49,7 +49,7 @@ jobs:
   build-autotools-gcc-no-window:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup
@@ -60,7 +60,7 @@ jobs:
   build-autotools-clang:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: ./.github/actions/setup


### PR DESCRIPTION
This should get rid of the CI deprecation warnings.

I've also adjusted the autotools doxygen command to match 2efd6a98a58fd8b32b802a675a52cb8383f2d0ea.
