### PR TITLE
[Textbox] Draw text after cursor

### DIFF
--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -518,28 +518,6 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
   }
   }
 
-  // draw the text
-  cairo_save(draw);
-  cairo_reset_clip(draw);
-
-  gboolean show_outline =
-      rofi_theme_get_boolean(WIDGET(tb), "text-outline", FALSE);
-  if (tb->show_placeholder) {
-    rofi_theme_get_color(WIDGET(tb), "placeholder-color", draw);
-    show_outline = FALSE;
-  }
-  pango_cairo_show_layout(draw, tb->layout);
-
-  if (show_outline) {
-    rofi_theme_get_color(WIDGET(tb), "text-outline-color", draw);
-    double width = rofi_theme_get_double(WIDGET(tb), "text-outline-width", 0.5);
-    pango_cairo_layout_path(draw, tb->layout);
-    cairo_set_line_width(draw, width);
-    cairo_stroke(draw);
-  }
-
-  cairo_restore(draw);
-
   // draw the cursor
   if (tb->flags & TB_EDITABLE) {
     // We want to place the cursor based on the text shown.
@@ -563,6 +541,7 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
     if (tb->blink) {
       // use text color as fallback for themes that don't specify the cursor
       // color
+      cairo_save(draw);
       rofi_theme_get_color(WIDGET(tb), "cursor-color", draw);
       cairo_rectangle(draw, x + cursor_x, y + cursor_y, cursor_pixel_width,
                       cursor_height);
@@ -576,8 +555,31 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
       } else {
         cairo_fill(draw);
       }
+      cairo_restore(draw);
     }
   }
+
+  // draw the text
+  cairo_save(draw);
+  cairo_reset_clip(draw);
+
+  gboolean show_outline =
+      rofi_theme_get_boolean(WIDGET(tb), "text-outline", FALSE);
+  if (tb->show_placeholder) {
+    rofi_theme_get_color(WIDGET(tb), "placeholder-color", draw);
+    show_outline = FALSE;
+  }
+  pango_cairo_show_layout(draw, tb->layout);
+
+  if (show_outline) {
+    rofi_theme_get_color(WIDGET(tb), "text-outline-color", draw);
+    double width = rofi_theme_get_double(WIDGET(tb), "text-outline-width", 0.5);
+    pango_cairo_layout_path(draw, tb->layout);
+    cairo_set_line_width(draw, width);
+    cairo_stroke(draw);
+  }
+
+  cairo_restore(draw);
 }
 
 // cursor handling for edit mode


### PR DESCRIPTION
A couple of weeks ago my PR (https://github.com/davatorium/rofi/pull/1753) was merged, making it possible to create block cursors. As part of that change I made the text render on top of the cursor so that text can still be read even when the cursor is at the same position. This change was reverted with [this commit](https://github.com/davatorium/rofi/commit/3d73cf25541a5ea3dceb864a15f8ad4f654615da), effectively breaking block cursors again.

For reference, here is a screenshot of the current state 
![2023-01-10_03-01-1673319401](https://user-images.githubusercontent.com/24727270/211451592-55ea09c9-4e14-4130-89b4-e791cf3ebe6f.png)

And here is what it's supposed to look like:
![2023-01-10_03-01-1673318694](https://user-images.githubusercontent.com/24727270/211451224-529a07c4-637d-4b03-832c-812f57ce4abf.png)

I myself don't see a reason for why the text can't be on top of the cursor so I opened this PR to fix that regression.