### PR TITLE
[rofi-theme-selector] prepend newline before specifying new theme

### DIFF
--- a/script/rofi-theme-selector
+++ b/script/rofi-theme-selector
@@ -200,7 +200,7 @@ set_theme()
     fi
 
     # Comment old base theme, not replace as it may be modified after the line
-    ${SED} -i 's/^\s*\(@theme\s\+".*"\)/\/\/\1/' "${get_link}"
+    ${SED} -i 's,^\s*\(@theme\s\+".*"\),\/\/\1,' "${get_link}"
     echo -e "\n@theme \"${1}\"" >> "${get_link}"
 }
 

--- a/script/rofi-theme-selector
+++ b/script/rofi-theme-selector
@@ -198,8 +198,10 @@ set_theme()
     then
        touch "${get_link}"
     fi
+
+    # Comment old base theme, not replace as it may be modified after the line
     ${SED} -i 's/^\s*\(@theme\s\+".*"\)/\/\/\1/' "${get_link}"
-    echo "@theme \"${1}\"" >> "${get_link}"
+    echo -e "\n@theme \"${1}\"" >> "${get_link}"
 }
 
 ############################################################################################################

--- a/script/rofi-theme-selector
+++ b/script/rofi-theme-selector
@@ -200,7 +200,7 @@ set_theme()
     fi
 
     # Comment old base theme, not replace as it may be modified after the line
-    ${SED} -i 's,^\s*\(@theme\s\+".*"\),\/\/\1,' "${get_link}"
+    ${SED} -i '/^\s*@theme/ s,^,//,' "${get_link}"
     echo -e "\n@theme \"${1}\"" >> "${get_link}"
 }
 


### PR DESCRIPTION
If the EOF is not a newline, new theme setting will fail.