### PR TITLE
Add support for adding textbox widgets to listview elements

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -29,6 +29,7 @@
 #define ROFI_VIEW_H
 
 #include "mode.h"
+#include "widgets/widget.h"
 #include <pango/pango.h>
 #include <xcb/xcb.h>
 /**
@@ -354,6 +355,11 @@ void rofi_view_ellipsize_listview(RofiViewState *state,
  * main_window
  */
 gboolean rofi_set_im_window_pos(int new_x, int new_y);
+
+
+WidgetTriggerActionResult textbox_button_trigger_action(
+    widget *wid, MouseBindingMouseDefaultAction action, G_GNUC_UNUSED gint x,
+    G_GNUC_UNUSED gint y, G_GNUC_UNUSED void *user_data);
 
 /** @} */
 #endif

--- a/source/view.c
+++ b/source/view.c
@@ -2115,7 +2115,7 @@ static int rofi_view_calculate_height(RofiViewState *state) {
   return widget_get_desired_height(main_window, state->width);
 }
 
-static WidgetTriggerActionResult textbox_button_trigger_action(
+WidgetTriggerActionResult textbox_button_trigger_action(
     widget *wid, MouseBindingMouseDefaultAction action, G_GNUC_UNUSED gint x,
     G_GNUC_UNUSED gint y, G_GNUC_UNUSED void *user_data) {
   RofiViewState *state = (RofiViewState *)user_data;

--- a/source/widgets/listview.c
+++ b/source/widgets/listview.c
@@ -36,6 +36,7 @@
 
 #include "settings.h"
 #include "theme.h"
+#include "view.h"
 
 #include "timings.h"
 
@@ -187,6 +188,23 @@ static void listview_add_widget(listview *lv, _listview_row *row, widget *wid,
         textbox_create(wid, WIDGET_TYPE_TEXTBOX_TEXT, label,
                        TB_AUTOHEIGHT | TB_WRAP, NORMAL, "", 0, 0);
     box_add((box *)wid, WIDGET(textbox_custom), TRUE);
+  } else if (strncasecmp(label, "button", 6) == 0) {
+    textbox *button_custom =
+        textbox_create(wid, WIDGET_TYPE_EDITBOX, label,
+                       TB_AUTOHEIGHT | TB_WRAP, NORMAL, "", 0, 0);
+    box_add((box *)wid, WIDGET(button_custom), TRUE);
+    widget_set_trigger_action_handler(WIDGET(button_custom), textbox_button_trigger_action,
+                                      lv->udata);
+  } else if (strncasecmp(label, "icon", 4) == 0) {
+    icon *icon_custom = icon_create(wid, label);
+    /* small hack to make it clickable */
+    const char *type = rofi_theme_get_string(WIDGET(icon_custom), "action", NULL);
+    if (type) {
+      WIDGET(icon_custom)->type = WIDGET_TYPE_EDITBOX;
+    }
+    box_add((box *)wid, WIDGET(icon_custom), TRUE);
+    widget_set_trigger_action_handler(WIDGET(icon_custom), textbox_button_trigger_action,
+                                      lv->udata);
   } else {
     widget *wid2 = (widget *)box_create(wid, label, ROFI_ORIENTATION_VERTICAL);
     box_add((box *)wid, WIDGET(wid2), TRUE);

--- a/source/widgets/listview.c
+++ b/source/widgets/listview.c
@@ -182,6 +182,11 @@ static void listview_add_widget(listview *lv, _listview_row *row, widget *wid,
         textbox_create(WIDGET(wid), WIDGET_TYPE_TEXTBOX_TEXT, "element-index",
                        TB_AUTOHEIGHT, NORMAL, " ", 0, 0);
     box_add((box *)wid, WIDGET(row->index), FALSE);
+  } else if (strncasecmp(label, "textbox", 7) == 0) {
+    textbox *textbox_custom =
+        textbox_create(wid, WIDGET_TYPE_TEXTBOX_TEXT, label,
+                       TB_AUTOHEIGHT | TB_WRAP, NORMAL, "", 0, 0);
+    box_add((box *)wid, WIDGET(textbox_custom), TRUE);
   } else {
     widget *wid2 = (widget *)box_create(wid, label, ROFI_ORIENTATION_VERTICAL);
     box_add((box *)wid, WIDGET(wid2), TRUE);


### PR DESCRIPTION
This PR adds support for adding custom _textbox_ widgets as children of _element_ widgets.

This allows themes to add static text to entries that can be styled according to state (selected, alternate, ...).

My personal use-case is a powerline-theme, that uses custom _textbox_ widgets for the powerline-symbols.
Before, only custom _box_ widgets were supported (ie. no support for displaying text), and using _*-display-format_ does not allow for different styling depending on state.