### PR TITLE
Add wezterm to rofi-sensible-terminal

### DIFF
--- a/doc/rofi-sensible-terminal.1
+++ b/doc/rofi-sensible-terminal.1
@@ -55,6 +55,8 @@ konsole
 alacritty
 .IP \(bu 2
 kitty
+.IP \(bu 2
+wezterm
 
 .RE
 

--- a/doc/rofi-sensible-terminal.1.markdown
+++ b/doc/rofi-sensible-terminal.1.markdown
@@ -35,6 +35,7 @@ It tries to start one of the following (in that order):
 * konsole
 * alacritty
 * kitty
+* wezterm
 
 
 ## SEE ALSO

--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -9,7 +9,7 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm roxterm xfce4-terminal.wrapper mate-terminal lxterminal konsole alacritty kitty; do
+for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm roxterm xfce4-terminal.wrapper mate-terminal lxterminal konsole alacritty kitty wezterm; do
     if command -v $terminal >/dev/null 2>&1; then
         exec $terminal "$@"
     fi


### PR DESCRIPTION
I would like to add wezterm as it is a popular terminal these days and has many users.

https://github.com/wez/wezterm