### PR TITLE
Update rofi-sensible-terminal to include wezterm

### DIFF
--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -9,7 +9,7 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm roxterm xfce4-terminal.wrapper mate-terminal lxterminal konsole alacritty kitty; do
+for terminal in $TERMINAL x-terminal-emulator urxvt rxvt st terminology qterminal Eterm aterm uxterm xterm roxterm xfce4-terminal.wrapper mate-terminal lxterminal konsole alacritty kitty wezterm; do
     if command -v $terminal >/dev/null 2>&1; then
         exec $terminal "$@"
     fi


### PR DESCRIPTION
Adds wezterm so that users using wezterm, a fairly popular terminal, launching .desktop files with `terminal = true` don't have to deal with the "Failed to find suitable terminal" message.