### PR TITLE
Fix text color when `cursor-color` is set

### DIFF
--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -540,6 +540,8 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
       tb->cursor_x_pos = x + cursor_x;
     }
     if (tb->blink) {
+      // This save/restore state is necessary to render the text in the
+      // correct color when `cursor-color` is set
       cairo_save(draw);
       // use text color as fallback for themes that don't specify the cursor
       // color

--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -540,6 +540,7 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
       tb->cursor_x_pos = x + cursor_x;
     }
     if (tb->blink) {
+      cairo_save(draw);
       // use text color as fallback for themes that don't specify the cursor
       // color
       rofi_theme_get_color(WIDGET(tb), "cursor-color", draw);
@@ -555,6 +556,7 @@ static void textbox_draw(widget *wid, cairo_t *draw) {
       } else {
         cairo_fill(draw);
       }
+      cairo_restore(draw);
     }
   }
 


### PR DESCRIPTION
There was a regression in commit a5bd8bc63095d80ea3ad6f462138c23dc57c4e74 that makes text render in the same color as the cursor when `cursor-color` is set. This fixes the issue by correctly saving the state before setting the cursor color and restoring it afterwards.