### PR TITLE
Fix for a crash under FVWM3

### DIFF
--- a/source/xcb.c
+++ b/source/xcb.c
@@ -1636,7 +1636,7 @@ static void x11_helper_discover_window_manager(void) {
         xcb_ewmh_get_wm_name_unchecked(&(xcb->ewmh), wm_win);
     if (xcb_ewmh_get_wm_name_reply(&(xcb->ewmh), cookie, &wtitle, (void *)0)) {
       if (wtitle.strings_len > 0) {
-        g_debug("Found window manager: |%s|", wtitle.strings);
+        g_debug("Found window manager: |%.*s|", wtitle.strings_len, wtitle.strings);
         if (g_strcmp0(wtitle.strings, "i3") == 0) {
           current_window_manager =
               WM_DO_NOT_CHANGE_CURRENT_DESKTOP | WM_PANGO_WORKSPACE_NAMES;


### PR DESCRIPTION
Core was generated by `rofi'.
Program terminated with signal SIGSEGV, Segmentation fault. 0  strlen () at /usr/src/lib/libc/arch/amd64/string/strlen.S:125
125             movq    (%rax),%rdx             /* get bytes to check */
(gdb) bt
0  strlen () at /usr/src/lib/libc/arch/amd64/string/strlen.S:125
1  0x000008dfab6e1558 in __vfprintf (fp=<optimized out>, fmt0=<optimized out>, ap=<optimized out>) at /usr/src/lib/libc/stdio/vfprintf.c:877
2  0x000008dfab6da5a5 in _libc_vasprintf (str=0x7de1bf300610, fmt=0x8dd3e926e47 "Found window manager: |%s|", ap=0x7de1bf300800) at /usr/src/lib/libc/stdio/vasprintf.c:43
3  0x000008df5bfdfac7 in g_vasprintf () from /usr/local/lib/libglib-2.0.so.4201.10
4  0x000008df5bfa412d in g_strdup_vprintf () from /usr/local/lib/libglib-2.0.so.4201.10
5  0x000008df5bf86b3b in g_logv () from /usr/local/lib/libglib-2.0.so.4201.10
6  0x000008df5bf86a55 in g_log () from /usr/local/lib/libglib-2.0.so.4201.10
7  0x000008dd3e9853b2 in x11_helper_discover_window_manager () at ../source/xcb.c:1639
8  0x000008dd3e984d18 in display_setup (main_loop=0x8df6826b320, bindings=0x8df77e08220) at ../source/xcb.c:1696
9  0x000008dd3e954c03 in main (argc=9, argv=0x7de1bf300a58) at ../source/rofi.c:1021
(gdb) f 7
7  0x000008dd3e9853b2 in x11_helper_discover_window_manager () at ../source/xcb.c:1639
1639            g_debug("Found window manager: |%s|", wtitle.strings);
(gdb) p wtitle.strings
$1 = 0x8dfb80a2f50 "FVWM", '\325' <repeats 12 times>, '\337' <repeats 159 times>, <incomplete sequence \337><error: Cannot access memory at address 0x8dfb80a3000>

wtitle.strings is not NULL terminated, handle it with providing string length

Patch by Omar Polo

https://marc.info/?l=openbsd-ports&m=169606431614242&w=2
