### PR TITLE
Changed "Linux" to "GNU"

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Below is a list of the different modes:
 
 -   **combi**: Combine multiple modes into one.
 
-**Rofi** is known to work on Linux and BSD.
+**Rofi** is known to work on GNU and BSD.
 
 ## Manpage
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Below is a list of the different modes:
 
 -   **combi**: Combine multiple modes into one.
 
-**Rofi** is known to work on GNU and BSD.
+**Rofi** is known to work on GNU/Linux and BSD.
 
 ## Manpage
 


### PR DESCRIPTION
Linux is just a kernel (the best one). Whilst GNU is the actual "OS", hence this makes more sense I think.