### PR TITLE
Fix typo in dynamic_themes.md

### DIFF
--- a/mkdocs/docs/guides/DynamicThemes/dynamic_themes.md
+++ b/mkdocs/docs/guides/DynamicThemes/dynamic_themes.md
@@ -170,7 +170,7 @@ These will be merged into the theme on load:
 Now if we run it:
 
 ```bash
-REVIEW=true rofi -theme fullscreen-preview.rasi -show filebrowser
+PREVIEW=true rofi -theme fullscreen-preview.rasi -show filebrowser
 ```
 
 It looks like this:


### PR DESCRIPTION
Add missing "P" in "PREVIEW=true"

```bash
PREVIEW=true rofi -theme fullscreen-preview.rasi -show filebrowser
```
