### PR TITLE
[Build] Reduce amount of warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ AM_PROG_AR
 dnl ---------------------------------------------------------------------
 dnl Base CFLAGS
 dnl ---------------------------------------------------------------------
-AM_CFLAGS="-Wall -Wextra -Wparentheses -Winline -pedantic  -Wunreachable-code"
+AM_CFLAGS="-Wall -Wextra -Wparentheses -Winline -pedantic -Wno-overlength-strings -Wunreachable-code"
 
 dnl ---------------------------------------------------------------------
 dnl Enable source code coverage reporting for GCC

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ flags = [
     '-Winline',
     '-Wunreachable-code',
     '-Werror=missing-prototypes',
+    '-Wno-overlength-strings',
     '-Wno-inline' # A bit too noisy with Bison…
 ]
 foreach f : flags

--- a/source/modes/recursivebrowser.c
+++ b/source/modes/recursivebrowser.c
@@ -335,7 +335,7 @@ static unsigned int recursive_browser_mode_get_num_entries(const Mode *sw) {
   return pd->array_length;
 }
 
-static ModeMode recursive_browser_mode_result(Mode *sw, int mretv, char **input,
+static ModeMode recursive_browser_mode_result(Mode *sw, int mretv, G_GNUC_UNUSED char **input,
                                               unsigned int selected_line) {
   ModeMode retv = MODE_EXIT;
   FileBrowserModePrivateData *pd =

--- a/source/rofi-icon-fetcher.c
+++ b/source/rofi-icon-fetcher.c
@@ -361,7 +361,7 @@ static void rofi_icon_fetcher_worker(thread_state *sdata,
       icon_path, sentry->wsize, sentry->hsize, TRUE, &error);
   if (error != NULL) {
     g_warning("Failed to load image: |%s| %d %d %s (%p)", icon_path,
-              sentry->wsize, sentry->hsize, error->message, pb);
+              sentry->wsize, sentry->hsize, error->message, (void*)pb);
     g_error_free(error);
     if (pb) {
       g_object_unref(pb);

--- a/source/xcb.c
+++ b/source/xcb.c
@@ -775,7 +775,7 @@ static int monitor_get_dimension(int monitor_id, workarea *mon) {
 // find the dimensions of the monitor displaying point x,y
 static void monitor_dimensions(int x, int y, workarea *mon) {
   if (mon == NULL) {
-    g_error("%s: mon == NULL", __FUNCTION__);
+    g_error("%s: mon == NULL", __func__);
     return;
   }
   memset(mon, 0, sizeof(workarea));
@@ -818,7 +818,7 @@ static int pointer_get(xcb_window_t root, int *x, int *y) {
 
 static int monitor_active_from_winid(xcb_drawable_t id, workarea *mon) {
   if (mon == NULL) {
-    g_error("%s: mon == NULL", __FUNCTION__);
+    g_error("%s: mon == NULL", __func__);
     return FALSE;
   }
   xcb_window_t root = xcb->screen->root;
@@ -851,7 +851,7 @@ static int monitor_active_from_id_focused(int mon_id, workarea *mon) {
   xcb_window_t active_window;
   xcb_get_property_cookie_t awc;
   if (mon == NULL) {
-    g_error("%s: mon == NULL", __FUNCTION__);
+    g_error("%s: mon == NULL", __func__);
     return retv;
   }
   awc = xcb_ewmh_get_active_window(&xcb->ewmh, xcb->screen_nbr);
@@ -920,7 +920,7 @@ static int monitor_active_from_id(int mon_id, workarea *mon) {
   xcb_window_t root = xcb->screen->root;
   int x, y;
   if (mon == NULL) {
-    g_error("%s: mon == NULL", __FUNCTION__);
+    g_error("%s: mon == NULL", __func__);
     return FALSE;
   }
   g_debug("Monitor id: %d", mon_id);
@@ -1000,7 +1000,7 @@ workarea mon_cache = {
 };
 int monitor_active(workarea *mon) {
   if (mon == NULL) {
-    g_error("%s: mon == NULL", __FUNCTION__);
+    g_error("%s: mon == NULL", __func__);
     return FALSE;
   }
   g_debug("Monitor active");


### PR DESCRIPTION
Remove some warnings which pop up when building rofi and hide real issues when developing

* one unused parameter in recursivebrowser.c
* overlength strings are overly pedantic, modern compilers support large strings
* `__FUNCTION__` creeped back in after #288

What's left:

* non conformant cast in libgwater
```
../subprojects/libgwater/xcb/libgwater-xcb.c:160:35: warning: ISO C forbids conversion of object pointer to function pointer type [-Wpedantic]
  160 |     g_source_set_callback(source, (GSourceFunc)(void *)callback, user_data, destroy_func);
```
* unchecked return values (always `write()`, dmenu.c and recursivebrowser.c)
```
../source/modes/dmenu.c:309:19: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  309 |                   write(pd->pipefd2[1], "r", 1);
```