### PR TITLE
Add border_width to window coordinates

### DIFF
--- a/include/xcb.h
+++ b/include/xcb.h
@@ -209,8 +209,6 @@ typedef enum {
   WM_DO_NOT_CHANGE_CURRENT_DESKTOP = 1,
   /** PANGO WORKSPACE NAMES */
   WM_PANGO_WORKSPACE_NAMES = 2,
-  /** Root window offset (for bspwm) */
-  WM_ROOT_WINDOW_OFFSET = 4,
 } WindowManagerQuirk;
 
 /**

--- a/source/xcb.c
+++ b/source/xcb.c
@@ -890,8 +890,13 @@ static int monitor_active_from_id_focused(int mon_id, workarea *mon) {
       // place the menu above the window
       // if some window is focused, place menu above window, else fall
       // back to selected monitor.
-      mon->x = t->dst_x - r->x + r->border_width;
-      mon->y = t->dst_y - r->y + r->border_width;
+      if (tree_reply->parent == r->root) {
+        mon->x = t->dst_x - r->x + r->border_width;
+        mon->y = t->dst_y - r->y + r->border_width;
+      } else {
+        mon->x = t->dst_x;
+        mon->y = t->dst_y;
+      }
       mon->w = r->width;
       mon->h = r->height;
       retv = TRUE;

--- a/source/xcb.c
+++ b/source/xcb.c
@@ -890,8 +890,8 @@ static int monitor_active_from_id_focused(int mon_id, workarea *mon) {
       // place the menu above the window
       // if some window is focused, place menu above window, else fall
       // back to selected monitor.
-      mon->x = t->dst_x - r->x;
-      mon->y = t->dst_y - r->y;
+      mon->x = t->dst_x - r->x + r->border_width;
+      mon->y = t->dst_y - r->y + r->border_width;
       mon->w = r->width;
       mon->h = r->height;
       retv = TRUE;

--- a/source/xcb.c
+++ b/source/xcb.c
@@ -881,42 +881,38 @@ static int monitor_active_from_id_focused(int mon_id, workarea *mon) {
     free(tree_reply);
     return retv;
   }
-  xcb_translate_coordinates_cookie_t ct = xcb_translate_coordinates(
-      xcb->connection, tree_reply->parent, r->root, r->x, r->y);
-  xcb_translate_coordinates_reply_t *t =
-      xcb_translate_coordinates_reply(xcb->connection, ct, NULL);
-  if (t) {
-    if (mon_id == -2) {
-      // place the menu above the window
-      // if some window is focused, place menu above window, else fall
-      // back to selected monitor.
-      if (tree_reply->parent == r->root) {
-        mon->x = t->dst_x - r->x + r->border_width;
-        mon->y = t->dst_y - r->y + r->border_width;
-      } else {
-        mon->x = t->dst_x;
-        mon->y = t->dst_y;
-      }
-      mon->w = r->width;
-      mon->h = r->height;
-      retv = TRUE;
-      if ((current_window_manager & WM_ROOT_WINDOW_OFFSET) ==
-          WM_ROOT_WINDOW_OFFSET) {
-        mon->x += r->x;
-        mon->y += r->y;
-      }
-      g_debug("mon pos: %d %d %d-%d", mon->x, mon->y, mon->w, mon->h);
-    } else if (mon_id == -4) {
-      g_debug("Find monitor at location: %d %d", t->dst_x, t->dst_y);
-      monitor_dimensions(t->dst_x, t->dst_y, mon);
-      g_debug("Monitor found pos: %d %d %d-%d", mon->x, mon->y, mon->w, mon->h);
-      retv = TRUE;
+  if (tree_reply->parent != r->root) {
+    xcb_translate_coordinates_cookie_t ct = xcb_translate_coordinates(
+        xcb->connection, tree_reply->parent, r->root, r->x, r->y);
+    xcb_translate_coordinates_reply_t *t =
+        xcb_translate_coordinates_reply(xcb->connection, ct, NULL);
+    if (t) {
+      r->x = t->dst_x;
+      r->y = t->dst_y;
+      free(t);
+    } else {
+      g_debug("Failed to get translate position of active window, falling back "
+              "to mouse location (-5).");
+      free(r);
+      free(tree_reply);
+      return retv;
     }
-    free(t);
-  } else {
-    g_debug("Failed to get translate position of active window, falling back "
-            "to mouse location (-5).");
   }
+  if (mon_id == -2) {
+    // place the menu above the window
+    // if some window is focused, place menu above window, else fall
+    // back to selected monitor.
+    mon->x = r->x + r->border_width;
+    mon->y = r->y + r->border_width;
+    mon->w = r->width;
+    mon->h = r->height;
+    retv = TRUE;
+  } else if (mon_id == -4) {
+    g_debug("Find monitor at location: %d %d", r->x, r->y);
+    monitor_dimensions(r->x, r->y, mon);
+    retv = TRUE;
+  }
+  g_debug("mon pos: %d %d %d-%d", mon->x, mon->y, mon->w, mon->h);
   free(r);
   free(tree_reply);
   return retv;
@@ -1647,8 +1643,6 @@ static void x11_helper_discover_window_manager(void) {
         if (g_strcmp0(str, "i3") == 0) {
           current_window_manager =
               WM_DO_NOT_CHANGE_CURRENT_DESKTOP | WM_PANGO_WORKSPACE_NAMES;
-        } else if (g_strcmp0(str, "bspwm") == 0) {
-          current_window_manager = WM_ROOT_WINDOW_OFFSET;
         }
         g_free(str);
       }


### PR DESCRIPTION
In reference to #1968, this patch is to account to border_width for window coordinates when displaying on the currently focused window (`-monitor -2`).

Rather then add border width to the window's height and width, we are moving the x, y offsets. _100% of the window would be everything but the border_. I looked through xlib manual and icccm, but did not come across a defacto standard for this.