### PR TITLE
Fix some compiler warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -673,6 +673,7 @@ desktop_DATA=\
 	data/rofi-theme-selector.desktop
 
 EXTRA_DIST += \
+	doc/man_filter.lua \
 	doc/meson.build \
 	subprojects/libgwater/mpd/meson.build \
 	subprojects/libgwater/nl/meson.build \
@@ -697,6 +698,7 @@ EXTRA_DIST += \
 	subprojects/libgwater/alsa-mixer/libgwater-alsa-mixer.h \
 	subprojects/libgwater/alsa-mixer/libgwater-alsa-mixer.c \
 	data/rofi.png\
+	meson-dist-script \
 	meson_options.txt \
 	meson.build
 

--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ AM_PROG_AR
 dnl ---------------------------------------------------------------------
 dnl Base CFLAGS
 dnl ---------------------------------------------------------------------
-AM_CFLAGS="-Wall -Wextra -Wparentheses -Winline -pedantic -Wno-overlength-strings -Wunreachable-code"
+AM_CFLAGS="-Wall -Wextra -Wparentheses -Wno-inline -pedantic -Wno-overlength-strings -Wunreachable-code"
 
 dnl ---------------------------------------------------------------------
 dnl Enable source code coverage reporting for GCC

--- a/source/rofi-icon-fetcher.c
+++ b/source/rofi-icon-fetcher.c
@@ -210,11 +210,11 @@ static gboolean exec_thumbnailer_command(gchar **command_args) {
     NULL, G_SPAWN_DEFAULT | G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL, &wait_status, &error);
 
   if (spawned) {
-    return g_spawn_check_exit_status(wait_status, NULL);
+    return g_spawn_check_wait_status(wait_status, NULL);
   } else {
     g_warning("Error calling thumbnailer: %s", error->message);
     g_error_free(error);
-    
+
     return FALSE;
   }
 }


### PR DESCRIPTION
* -Wno-inline in autoconf builds (was already in meson builds)
* Use non-deprecated name for g_spawn_check_wait_status
* Update libgwater
