### PR TITLE
Better XIM interaction by filtering modifiers

### DIFF
--- a/include/xcb-internal.h
+++ b/include/xcb-internal.h
@@ -36,6 +36,7 @@
 #include <libgwater-xcb.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_ewmh.h>
+#include <xcb/xcb_keysyms.h>
 
 #include <nkutils-bindings.h>
 
@@ -49,6 +50,7 @@ struct _xcb_stuff {
 #ifdef XCB_IMDKIT
   xcb_xic_t ic;
   xcb_xim_t *im;
+  xcb_key_symbols_t *syms;
 #endif
   xcb_ewmh_connection_t ewmh;
   xcb_screen_t *screen;

--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,7 @@ deps += [
     dependency('xcb-randr'),
     dependency('xcb-cursor'),
     dependency('xcb-xinerama'),
+    dependency('xcb-keysyms'),
     dependency('cairo-xcb'),
     dependency('libstartup-notification-1.0'),
 ]


### PR DESCRIPTION
After diagnosing both the server and client sides of xcb-imdkit, specifically rofi and fcitx5, it has been determined that modifiers are causing the slowdown. This is a follow-up to PR #1999.

A new dependency, `xcb-keysyms`, has been added to properly recognize modifier keys.

I only performed some basic tests based on my daily workflow, and it worked smoothly. Let's see if this fix can stand the test of time.