### PR TITLE
[DOC] make systemd-run example more reliable

### DIFF
--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -878,6 +878,10 @@ replaced at runtime:
 - `{ssh-client}`: the configured ssh client (see -ssh-client)
 - `{cmd}`: the command to execute
 - `{window}`: the window ID of the selected window (in `window-command`)
+- `{desktop_file_path}`: The absolute path to the desktop file launched
+- `{app_id}`: The desktop file's file name without `.desktop` suffix
+- `{desktop_id}`: The `{desktop_file_path}` but with all `/` replaced by `-`
+  (see https://specifications.freedesktop.org/desktop-entry-spec/latest/file-naming.html)
 
 It processes the string as follows: `{key}`
 is replaced by its value, if `{key}` is not set it is removed. If the `{key}`

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -609,7 +609,7 @@ Example to run applications in a dedicated cgroup with systemd. Requires a
 shell to escape and interpolate the unit name correctly.
 
 ```bash
-"bash -c 'systemd-run --user --unit=app-rofi-\"\$(systemd-escape \"\$(basename \"{cmd}\")\")\"-\$RANDOM {cmd}'"
+"bash -c 'systemd-run --user --unit=app-rofi-\"\$(systemd-escape \"{app_id}\")\"-\$RANDOM {cmd}'"
 ```
 
 `-run-shell-command` *cmd*

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -609,7 +609,7 @@ Example to run applications in a dedicated cgroup with systemd. Requires a
 shell to escape and interpolate the unit name correctly.
 
 ```bash
-"bash -c 'systemd-run --user --unit=app-rofi-\$(systemd-escape {cmd})-\$RANDOM {cmd}'"
+"bash -c 'systemd-run --user --unit=app-rofi-\"\$(systemd-escape \"\$(basename \"{cmd}\")\")\"-\$RANDOM {cmd}'"
 ```
 
 `-run-shell-command` *cmd*

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -609,7 +609,7 @@ Example to run applications in a dedicated cgroup with systemd. Requires a
 shell to escape and interpolate the unit name correctly.
 
 ```bash
-"bash -c 'systemd-run --user --unit=app-rofi-\"\$(systemd-escape \"{app_id}\")\"-\$RANDOM {cmd}'"
+"bash -c 'systemd-run --user [--unit=app-rofi-\"\$(systemd-escape \"{app_id}\")\"-\$RANDOM] {cmd}'"
 ```
 
 `-run-shell-command` *cmd*

--- a/include/helper.h
+++ b/include/helper.h
@@ -331,6 +331,23 @@ gboolean helper_execute_command(const char *wd, const char *cmd,
                                 RofiHelperExecuteContext *context);
 
 /**
+ * @param wd The work directory (optional)
+ * @param cmd The cmd to execute
+ * @param run_in_term Indicate if command should be run in a terminal
+ * @param context The startup notification context, if any
+ * @param ... tuples of extra parameters the string can search/replace
+ *
+ * Execute command.
+ * If needed members of context are NULL, they will be filled.
+ * Pass {cmd} into the va-arg list.
+ *
+ * @returns FALSE On failure, TRUE on success
+ */
+gboolean helper_execute_command_full(const char *wd, const char *cmd,
+                                     gboolean run_in_term,
+                                     RofiHelperExecuteContext *context, ...);
+
+/**
  * @param file The file path
  * @param height The wanted height
  * Gets a surface from an svg path

--- a/source/modes/drun.c
+++ b/source/modes/drun.c
@@ -402,7 +402,10 @@ static void exec_cmd_entry(DRunModeEntry *e, const char *path) {
   // terminal.
   gboolean terminal =
       g_key_file_get_boolean(e->key_file, e->action, "Terminal", NULL);
-  if (helper_execute_command(exec_path, fp, terminal, sn ? &context : NULL)) {
+  if (helper_execute_command_full(exec_path, fp, terminal, sn ? &context : NULL,
+                                  "{cmd}", fp, "{desktop_file_path}", e->path,
+                                  "{app_id}", e->app_id, "{desktop_id}",
+                                  e->desktop_id, (char *)0)) {
     char *drun_cach_path = g_build_filename(cache_dir, DRUN_CACHE_FILE, NULL);
     // Store it based on the unique identifiers (desktop_id).
     history_set(drun_cach_path, e->desktop_id);


### PR DESCRIPTION
This is a follow-up to https://github.com/davatorium/rofi/pull/1752/

If the `{cmd}` had spaces in it, it would error out with something like

    Failed to find executable gui-22345: No such file or directory

(In this case the command was
`/nix/store/6jlqjighx0v0lqx9bahc7nl6npshim2r-lact-0.5.6/bin/lact gui`)

This fixes that.

What this also fixes is that this would result in incredibly long names such as `--unit=app-rofi--nix-store-6jlqjighx0v0lqx9bahc7nl6npshim2r\x2dlact\x2d0.5.6-bin-lact` because the desktop entry contained the full path which can be quite long in Nix and is quite common in Nix packaging.

We only really care about the executable name here.

The current iteration still has command arguments in its name but getting rid of those would be quite bothersome in bash. IME apps also usually don't have command line args and if they do it's usually something short like in the example above. This could certainly be improved though.

cc @mweinelt 