### PR TITLE
Fix buffer overflow in rofi -e after reading from stdin

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -823,6 +823,8 @@ static gboolean startup(G_GNUC_UNUSED gpointer data) {
         msg = realloc(msg, length * sizeof(char));
       }
 
+      msg[index] = 0;
+
       if (!rofi_view_error_dialog(msg, markup)) {
         g_main_loop_quit(main_loop);
       }


### PR DESCRIPTION
See #2081 for more info. This fixes the problem. Tested it.

It is always possible to write at `msg[index]` since there will be exactly 1024 bytes free after the read data, which ends at `index -1`.