### PR TITLE
Add option to enable the `kb-delete-entry` in script mode

### DIFF
--- a/Examples/test_script_env.sh
+++ b/Examples/test_script_env.sh
@@ -9,7 +9,6 @@ fi
 echo -en "\x00no-custom\x1ffalse\n"
 echo -en "\x00data\x1fmonkey do, monkey did\n"
 echo -en "\x00use-hot-keys\x1ftrue\n"
-echo -en "\x00use-delete\x1ftrue\n"
 echo -en "${ROFI_RETV}\x00icon\x1ffirefox\x1finfo\x1ftest\n"
 
 if [ -n "${ROFI_INFO}" ]

--- a/Examples/test_script_env.sh
+++ b/Examples/test_script_env.sh
@@ -9,6 +9,7 @@ fi
 echo -en "\x00no-custom\x1ffalse\n"
 echo -en "\x00data\x1fmonkey do, monkey did\n"
 echo -en "\x00use-hot-keys\x1ftrue\n"
+echo -en "\x00use-delete\x1ftrue\n"
 echo -en "${ROFI_RETV}\x00icon\x1ffirefox\x1finfo\x1ftest\n"
 
 if [ -n "${ROFI_INFO}" ]

--- a/doc/rofi-script.5.markdown
+++ b/doc/rofi-script.5.markdown
@@ -59,6 +59,7 @@ An integer number with the current state:
 - **0**: Initial call of script.
 - **1**: Selected an entry.
 - **2**: Selected a custom entry.
+- **3**: Deleted an entry.
 - **10-28**: Custom keybinding 1-19 ( need to be explicitly enabled by script ).
 
 ### `ROFI_INFO`
@@ -106,10 +107,13 @@ The following extra options exists:
 -   **use-hot-keys**: If set to true, it enabled the Custom keybindings for
     script. Warning this breaks the normal rofi flow.
 
+-   **use-delete**: If set to true, it enables the `kb-delete-entry` keybinding for
+    script.
+
 -   **keep-selection**: If set, the selection is not moved to the first entry,
     but the current position is maintained. The filter is cleared.
 
--   **keep-filter**: If set, the filter is not cleared. 
+-   **keep-filter**: If set, the filter is not cleared.
 
 -   **new-selection**: If `keep-selection` is set, this allows you to override
     the selected entry (absolute position).

--- a/doc/rofi-script.5.markdown
+++ b/doc/rofi-script.5.markdown
@@ -107,9 +107,6 @@ The following extra options exists:
 -   **use-hot-keys**: If set to true, it enabled the Custom keybindings for
     script. Warning this breaks the normal rofi flow.
 
--   **use-delete**: If set to true, it enables the `kb-delete-entry` keybinding for
-    script.
-
 -   **keep-selection**: If set, the selection is not moved to the first entry,
     but the current position is maintained. The filter is cleared.
 

--- a/source/modes/script.c
+++ b/source/modes/script.c
@@ -76,7 +76,6 @@ typedef struct {
   gboolean keep_filter;
 
   gboolean use_hot_keys;
-  gboolean use_delete;
 } ScriptModePrivateData;
 
 /**
@@ -158,8 +157,6 @@ static void parse_header_entry(Mode *sw, char *line, ssize_t length) {
       pd->no_custom = (strcasecmp(value, "true") == 0);
     } else if (strcasecmp(line, "use-hot-keys") == 0) {
       pd->use_hot_keys = (strcasecmp(value, "true") == 0);
-    } else if (strcasecmp(line, "use-delete") == 0) {
-      pd->use_delete = (strcasecmp(value, "true") == 0);
     } else if (strcasecmp(line, "keep-selection") == 0) {
       pd->keep_selection = (strcasecmp(value, "true") == 0);
     } else if (strcasecmp(line, "keep-filter") == 0) {
@@ -351,7 +348,7 @@ static ModeMode script_mode_result(Mode *sw, int mretv, char **input,
       retv = (mretv & MENU_LOWER_MASK);
       return retv;
     }
-  } else if ((mretv & MENU_ENTRY_DELETE) && selected_line != UINT32_MAX && rmpd->use_delete) {
+  } else if ((mretv & MENU_ENTRY_DELETE) && selected_line != UINT32_MAX) {
     script_mode_reset_highlight(sw);
     new_list = execute_executor(sw, rmpd->cmd_list[selected_line].entry, &new_length,
                                 3, &(rmpd->cmd_list[selected_line]));

--- a/source/modes/script.c
+++ b/source/modes/script.c
@@ -76,6 +76,7 @@ typedef struct {
   gboolean keep_filter;
 
   gboolean use_hot_keys;
+  gboolean use_delete;
 } ScriptModePrivateData;
 
 /**
@@ -157,6 +158,8 @@ static void parse_header_entry(Mode *sw, char *line, ssize_t length) {
       pd->no_custom = (strcasecmp(value, "true") == 0);
     } else if (strcasecmp(line, "use-hot-keys") == 0) {
       pd->use_hot_keys = (strcasecmp(value, "true") == 0);
+    } else if (strcasecmp(line, "use-delete") == 0) {
+      pd->use_delete = (strcasecmp(value, "true") == 0);
     } else if (strcasecmp(line, "keep-selection") == 0) {
       pd->keep_selection = (strcasecmp(value, "true") == 0);
     } else if (strcasecmp(line, "keep-filter") == 0) {
@@ -348,6 +351,10 @@ static ModeMode script_mode_result(Mode *sw, int mretv, char **input,
       retv = (mretv & MENU_LOWER_MASK);
       return retv;
     }
+  } else if ((mretv & MENU_ENTRY_DELETE) && selected_line != UINT32_MAX && rmpd->use_delete) {
+    script_mode_reset_highlight(sw);
+    new_list = execute_executor(sw, rmpd->cmd_list[selected_line].entry, &new_length,
+                                3, &(rmpd->cmd_list[selected_line]));
   } else if ((mretv & MENU_OK) && rmpd->cmd_list[selected_line].entry != NULL) {
     if (rmpd->cmd_list[selected_line].nonselectable) {
       return RELOAD_DIALOG;


### PR DESCRIPTION
What this PR does:

- Enable the `kb-delete-entry` keybinding in scripts through a new `use-delete` option.
  - Default is `false` to maintain backward compatibility and avoid breaking existing behavior.
- Updated documentation to reflect the new state for entry deletion.
- Modified the script environment example to include the new option.

Reason:

This change enhances user control over entry management in scripts. Specifically, for clipboard management, providing the ability to delete clipboard entries is an important feature.