### PR TITLE
[scrollbar] Add theming for rounded corners

### DIFF
--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -1011,6 +1011,7 @@ The following properties are currently supported:
 - **handle-width**:        distance
 - **handle-color**:        color
 - **border-color**:        color
+- **rounded-corners**:     boolean for rounded scrollbar
 
 ### box
 

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -1011,7 +1011,7 @@ The following properties are currently supported:
 - **handle-width**:        distance
 - **handle-color**:        color
 - **border-color**:        color
-- **rounded-corners**:     boolean for rounded scrollbar
+- **handle-rounded-corners**:     boolean for rounded scrollbar
 
 ### box
 

--- a/source/widgets/scrollbar.c
+++ b/source/widgets/scrollbar.c
@@ -175,8 +175,26 @@ static void scrollbar_draw(widget *wid, cairo_t *draw) {
   // Cap length;
   rofi_theme_get_color(WIDGET(sb), "handle-color", draw);
 
-  cairo_rectangle(draw, widget_padding_get_left(wid),
-                  widget_padding_get_top(wid) + y,
-                  widget_padding_get_remaining_width(wid), height);
-  cairo_fill(draw);
+  if (rofi_theme_get_boolean(WIDGET(sb), "rounded-corners", FALSE)) {
+    float x = widget_padding_get_left(wid);
+    float width = widget_padding_get_remaining_width(wid);
+
+    float radius = ((width < height) ? width : height) / 2; // Limit radius to prevent overlap
+
+    // Draw rounded rectangle
+    cairo_new_sub_path(draw);
+    cairo_arc(draw, x + width - radius, y + radius, radius, -G_PI_2, 0);
+    cairo_arc(draw, x + width - radius, y + height - radius, radius, 0, G_PI_2);
+    cairo_arc(draw, x + radius, y + height - radius, radius, G_PI_2, G_PI);
+    cairo_arc(draw, x + radius, y + radius, radius, G_PI, 1.5 * G_PI);
+    cairo_close_path(draw);
+
+    cairo_fill(draw);
+  }
+  else {
+    cairo_rectangle(draw, widget_padding_get_left(wid),
+                    widget_padding_get_top(wid) + y,
+                    widget_padding_get_remaining_width(wid), height);
+    cairo_fill(draw);
+  }
 }

--- a/source/widgets/scrollbar.c
+++ b/source/widgets/scrollbar.c
@@ -175,7 +175,7 @@ static void scrollbar_draw(widget *wid, cairo_t *draw) {
   // Cap length;
   rofi_theme_get_color(WIDGET(sb), "handle-color", draw);
 
-  if (rofi_theme_get_boolean(WIDGET(sb), "rounded-corners", FALSE)) {
+  if (rofi_theme_get_boolean(WIDGET(sb), "handle-rounded-corners", FALSE)) {
     float x = widget_padding_get_left(wid);
     float width = widget_padding_get_remaining_width(wid);
 


### PR DESCRIPTION
This PR adds a new ``rounded-corners`` option in the ``scrollbar{ }`` category for theming.

Example: 
```
scrollbar {
    padding: 0px 0px 0px 10px;  
    rounded-corners: true;
    handle-width: 6px ;
    handle-color: red;
}
```