### PR TITLE
[Dmenu][Script] Add support for fallback icons

### DIFF
--- a/doc/rofi-script.5.markdown
+++ b/doc/rofi-script.5.markdown
@@ -138,7 +138,7 @@ For example:
 
 The following options are supported:
 
--   **icon**: Set the icon for that row.
+-   **icon**: Set the icon for that row. Multiple fallback icons can be specified using comma-separated values.
 
 -   **display**: Replace the displayed string. (Original string will still be used for filtering)
 
@@ -158,7 +158,7 @@ The following options are supported:
 multiple entries can be passed using the `\x1f` separator.
 
 ```bash
-    echo -en "aap\0icon\x1ffolder\x1finfo\x1ftest\n"
+    echo -en "aap\0icon\x1ffolder,inode-directory\x1finfo\x1ftest\n"
 ```
 
 ## Executing external program

--- a/include/modes/dmenuscriptshared.h
+++ b/include/modes/dmenuscriptshared.h
@@ -18,6 +18,8 @@ typedef struct {
   uint32_t icon_fetch_uid;
   uint32_t icon_fetch_size;
   guint icon_fetch_scale;
+  /** Current fallback icon index being tried */
+  int icon_fallback_index;
   /** Hidden meta keywords. */
   char *meta;
 

--- a/include/modes/dmenuscriptshared.h
+++ b/include/modes/dmenuscriptshared.h
@@ -13,7 +13,7 @@ typedef struct {
   char *display;
 
   /** Icon name to display. */
-  char *icon_name;
+  char **icon_name;
   /** Async icon fetch handler. */
   uint32_t icon_fetch_uid;
   uint32_t icon_fetch_size;

--- a/source/modes/dmenu.c
+++ b/source/modes/dmenu.c
@@ -724,12 +724,32 @@ static cairo_surface_t *dmenu_get_icon(const Mode *sw,
   if (dr->icon_name == NULL) {
     return NULL;
   }
-  uint32_t uid = dr->icon_fetch_uid =
+  if (strchr(dr->icon_name, ',') == NULL) {
+    uint32_t uid = dr->icon_fetch_uid =
       rofi_icon_fetcher_query(dr->icon_name, height);
   dr->icon_fetch_size = height;
   dr->icon_fetch_scale = scale;
 
-  return rofi_icon_fetcher_get(uid);
+    return rofi_icon_fetcher_get(uid);
+  } else {
+    cairo_surface_t *icon_surface = NULL;
+    char *icon_name_copy = g_strdup(dr->icon_name);
+    char *icon_iter = icon_name_copy;
+    char *icon = NULL;
+    // Try each icon in the comma-separated list until one is found
+    while ((icon = strsep(&icon_iter, ",")) != NULL) {
+      uint32_t uid = rofi_icon_fetcher_query(icon, height);
+      icon_surface = rofi_icon_fetcher_get(uid);
+      if (icon_surface != NULL) {
+        dr->icon_fetch_uid = uid;
+        dr->icon_fetch_size = height;
+        dr->icon_fetch_scale = scale;
+        break;
+      }
+    }
+    g_free(icon_name_copy);
+    return icon_surface;
+  }
 }
 
 static void dmenu_finish(DmenuModePrivateData *pd, RofiViewState *state,

--- a/source/modes/dmenu.c
+++ b/source/modes/dmenu.c
@@ -137,6 +137,7 @@ static void read_add_block(DmenuModePrivateData *pd, Block **block, char *data,
   (*block)->values[(*block)->length].icon_fetch_uid = 0;
   (*block)->values[(*block)->length].icon_fetch_size = 0;
   (*block)->values[(*block)->length].icon_fetch_scale = 0;
+  (*block)->values[(*block)->length].icon_fallback_index = 0;
   (*block)->values[(*block)->length].icon_name = NULL;
   (*block)->values[(*block)->length].meta = NULL;
   (*block)->values[(*block)->length].info = NULL;
@@ -169,6 +170,7 @@ static void read_add(DmenuModePrivateData *pd, char *data, gsize len) {
   pd->cmd_list[pd->cmd_list_length].icon_fetch_uid = 0;
   pd->cmd_list[pd->cmd_list_length].icon_fetch_size = 0;
   pd->cmd_list[pd->cmd_list_length].icon_fetch_scale = 0;
+  pd->cmd_list[pd->cmd_list_length].icon_fallback_index = 0;
   pd->cmd_list[pd->cmd_list_length].icon_name = NULL;
   pd->cmd_list[pd->cmd_list_length].display = NULL;
   pd->cmd_list[pd->cmd_list_length].meta = NULL;
@@ -724,25 +726,43 @@ static cairo_surface_t *dmenu_get_icon(const Mode *sw,
   if (dr->icon_name == NULL) {
     return NULL;
   }
-  cairo_surface_t *icon_surface = NULL;
+
+  if (dr->icon_fetch_uid > 0) {
+    cairo_surface_t *surface = NULL;
+    gboolean query_done = rofi_icon_fetcher_get_ex(dr->icon_fetch_uid, &surface);
+
+    if (surface != NULL) {
+      return surface;
+    } else if (query_done) {
+      dr->icon_fallback_index++;
+      dr->icon_fetch_uid = 0;
+    } else {
+      return NULL;
+    }
+  }
+
   char *icon_name_copy = g_strdup(dr->icon_name);
   char *icon_iter = icon_name_copy;
-  char *icon = NULL;
+  char *current_icon = NULL;
+  int current_index = 0;
 
   // Try each icon in the comma-separated list until one is found
-  while ((icon = strsep(&icon_iter, ",")) != NULL) {
-    uint32_t uid = rofi_icon_fetcher_query(icon, height);
-    icon_surface = rofi_icon_fetcher_get(uid);
-    if (icon_surface != NULL) {
-      dr->icon_fetch_uid = uid;
+  while ((current_icon = strsep(&icon_iter, ",")) != NULL) {
+    if (current_index == dr->icon_fallback_index) {
+      dr->icon_fetch_uid = rofi_icon_fetcher_query(current_icon, height);
       dr->icon_fetch_size = height;
       dr->icon_fetch_scale = scale;
       break;
     }
+    current_index++;
+  }
+
+  if (current_icon == NULL) {
+    dr->icon_fetch_uid = 0;
   }
 
   g_free(icon_name_copy);
-  return icon_surface;
+  return NULL;
 }
 
 static void dmenu_finish(DmenuModePrivateData *pd, RofiViewState *state,

--- a/source/modes/dmenu.c
+++ b/source/modes/dmenu.c
@@ -488,7 +488,7 @@ static void dmenu_mode_free(Mode *sw) {
     for (size_t i = 0; i < pd->cmd_list_length; i++) {
       if (pd->cmd_list[i].entry) {
         g_free(pd->cmd_list[i].entry);
-        g_free(pd->cmd_list[i].icon_name);
+        g_strfreev(pd->cmd_list[i].icon_name);
         g_free(pd->cmd_list[i].display);
         g_free(pd->cmd_list[i].meta);
         g_free(pd->cmd_list[i].info);
@@ -741,27 +741,22 @@ static cairo_surface_t *dmenu_get_icon(const Mode *sw,
     }
   }
 
-  char *icon_name_copy = g_strdup(dr->icon_name);
-  char *icon_iter = icon_name_copy;
   char *current_icon = NULL;
-  int current_index = 0;
-
-  // Try each icon in the comma-separated list until one is found
-  while ((current_icon = strsep(&icon_iter, ",")) != NULL) {
-    if (current_index == dr->icon_fallback_index) {
-      dr->icon_fetch_uid = rofi_icon_fetcher_query(current_icon, height);
-      dr->icon_fetch_size = height;
-      dr->icon_fetch_scale = scale;
-      break;
-    }
-    current_index++;
+  if (dr->icon_name && dr->icon_fallback_index >= 0) {
+      int icon_count = g_strv_length(dr->icon_name);
+      if (dr->icon_fallback_index < icon_count) {
+          current_icon = dr->icon_name[dr->icon_fallback_index];
+      }
   }
+  if ( current_icon ){
+    dr->icon_fetch_uid = rofi_icon_fetcher_query(current_icon, height);
+    dr->icon_fetch_size = height;
+    dr->icon_fetch_scale = scale;
 
-  if (current_icon == NULL) {
+  } else {
     dr->icon_fetch_uid = 0;
   }
 
-  g_free(icon_name_copy);
   return NULL;
 }
 

--- a/source/modes/dmenu.c
+++ b/source/modes/dmenu.c
@@ -724,32 +724,25 @@ static cairo_surface_t *dmenu_get_icon(const Mode *sw,
   if (dr->icon_name == NULL) {
     return NULL;
   }
-  if (strchr(dr->icon_name, ',') == NULL) {
-    uint32_t uid = dr->icon_fetch_uid =
-      rofi_icon_fetcher_query(dr->icon_name, height);
-  dr->icon_fetch_size = height;
-  dr->icon_fetch_scale = scale;
+  cairo_surface_t *icon_surface = NULL;
+  char *icon_name_copy = g_strdup(dr->icon_name);
+  char *icon_iter = icon_name_copy;
+  char *icon = NULL;
 
-    return rofi_icon_fetcher_get(uid);
-  } else {
-    cairo_surface_t *icon_surface = NULL;
-    char *icon_name_copy = g_strdup(dr->icon_name);
-    char *icon_iter = icon_name_copy;
-    char *icon = NULL;
-    // Try each icon in the comma-separated list until one is found
-    while ((icon = strsep(&icon_iter, ",")) != NULL) {
-      uint32_t uid = rofi_icon_fetcher_query(icon, height);
-      icon_surface = rofi_icon_fetcher_get(uid);
-      if (icon_surface != NULL) {
-        dr->icon_fetch_uid = uid;
-        dr->icon_fetch_size = height;
-        dr->icon_fetch_scale = scale;
-        break;
-      }
+  // Try each icon in the comma-separated list until one is found
+  while ((icon = strsep(&icon_iter, ",")) != NULL) {
+    uint32_t uid = rofi_icon_fetcher_query(icon, height);
+    icon_surface = rofi_icon_fetcher_get(uid);
+    if (icon_surface != NULL) {
+      dr->icon_fetch_uid = uid;
+      dr->icon_fetch_size = height;
+      dr->icon_fetch_scale = scale;
+      break;
     }
-    g_free(icon_name_copy);
-    return icon_surface;
   }
+
+  g_free(icon_name_copy);
+  return icon_surface;
 }
 
 static void dmenu_finish(DmenuModePrivateData *pd, RofiViewState *state,

--- a/source/modes/script.c
+++ b/source/modes/script.c
@@ -94,7 +94,8 @@ void dmenuscript_parse_entry_extras(G_GNUC_UNUSED Mode *sw,
     *(extra) = NULL;
     *(extra + 1) = NULL;
     if (strcasecmp(key, "icon") == 0) {
-      entry->icon_name = value;
+      entry->icon_name = g_strsplit(value,",", -1);
+      g_free(value);
     } else if (strcasecmp(key, "display") == 0) {
       entry->display = value;
     } else if (strcasecmp(key, "meta") == 0) {
@@ -409,7 +410,7 @@ static void script_mode_destroy(Mode *sw) {
   if (rmpd != NULL) {
     for (unsigned int i = 0; i < rmpd->cmd_list_length; i++) {
       g_free(rmpd->cmd_list[i].entry);
-      g_free(rmpd->cmd_list[i].icon_name);
+      g_strfreev(rmpd->cmd_list[i].icon_name);
       g_free(rmpd->cmd_list[i].display);
       g_free(rmpd->cmd_list[i].meta);
     }
@@ -518,20 +519,46 @@ static cairo_surface_t *script_get_icon(const Mode *sw,
                                         unsigned int height) {
   ScriptModePrivateData *pd =
       (ScriptModePrivateData *)mode_get_private_data(sw);
+
   const guint scale = display_scale();
+
   g_return_val_if_fail(pd->cmd_list != NULL, NULL);
   DmenuScriptEntry *dr = &(pd->cmd_list[selected_line]);
   if (dr->icon_name == NULL) {
     return NULL;
   }
-  if (dr->icon_fetch_uid > 0 && dr->icon_fetch_size == height &&
-      dr->icon_fetch_scale == scale) {
-    return rofi_icon_fetcher_get(dr->icon_fetch_uid);
+
+  if (dr->icon_fetch_uid > 0) {
+    cairo_surface_t *surface = NULL;
+    gboolean query_done = rofi_icon_fetcher_get_ex(dr->icon_fetch_uid, &surface);
+
+    if (surface != NULL) {
+      return surface;
+    } else if (query_done) {
+      dr->icon_fallback_index++;
+      dr->icon_fetch_uid = 0;
+    } else {
+      return NULL;
+    }
   }
-  dr->icon_fetch_uid = rofi_icon_fetcher_query(dr->icon_name, height);
-  dr->icon_fetch_size = height;
-  dr->icon_fetch_scale = scale;
-  return rofi_icon_fetcher_get(dr->icon_fetch_uid);
+
+  char *current_icon = NULL;
+  if (dr->icon_name && dr->icon_fallback_index >= 0) {
+      int icon_count = g_strv_length(dr->icon_name);
+      if (dr->icon_fallback_index < icon_count) {
+          current_icon = dr->icon_name[dr->icon_fallback_index];
+      }
+  }
+  if ( current_icon ){
+    dr->icon_fetch_uid = rofi_icon_fetcher_query(current_icon, height);
+    dr->icon_fetch_size = height;
+    dr->icon_fetch_scale = scale;
+
+  } else {
+    dr->icon_fetch_uid = 0;
+  }
+
+  return NULL;
 }
 
 #include "mode-private.h"


### PR DESCRIPTION
This adds support for fallback icons in dmenu mode using comma-separated values in the icon metadata. When the primary icon is not found, subsequent icons in the list will be tried until one is successfully loaded.

Example usage: "Firefox\0icon\x1ffirefox,web-browser,application-x-executable"
