### PR TITLE
[XWAYLAND] Immediate fix for no-typing issue on Wayland

### DIFF
--- a/source/view.c
+++ b/source/view.c
@@ -1157,6 +1157,10 @@ void __create_window(MenuFlags menu_flags) {
     window_set_atom_prop(box_window, xcb->ewmh._NET_WM_STATE,
                          &(xcb->ewmh._NET_WM_STATE_ABOVE), 1);
     uint32_t values[] = {1};
+    if (getenv("WAYLAND_DISPLAY") != NULL) {
+      x11_disable_decoration(box_window);
+      values[0] = 0;
+    }
     xcb_change_window_attributes(xcb->connection, box_window,
                                  XCB_CW_OVERRIDE_REDIRECT, values);
   } else {


### PR DESCRIPTION
I recently fixed this same typing issue on my own X11 program, and since the fix was so simple, and rofi is the only other wayland program I was missing, I thought I'd just send a patch for you guys.

The reason typing on X11 clients doesn't always work is because clients with override_redirect set to false don't get sent key presses (for some reason).

I've already tested this PR and it does indeed fix the no-typing problem (and the window is still positioned correctly on the screen).

(I do realize there is work being done to port rofi natively to Wayland, but this fix should prevent people from looking for Wayland alternatives to rofi while they wait. They can just use rofi.)
