### PR TITLE
Use portable input-codes.h for mouse button constants

### DIFF
--- a/include/input-codes.h
+++ b/include/input-codes.h
@@ -1,0 +1,44 @@
+/*
+ * rofi
+ *
+ * MIT/X11 License
+ * Copyright © 2025 Leandro Vital <leavitals@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef INPUT_CODES_H
+#define INPUT_CODES_H
+
+// Define BTN_* codes if not defined by the system headers
+#ifndef BTN_LEFT
+#define BTN_LEFT    0x110
+#endif
+
+#ifndef BTN_RIGHT
+#define BTN_RIGHT   0x111
+#endif
+
+#ifndef BTN_MIDDLE
+#define BTN_MIDDLE  0x112
+#endif
+
+#endif // INPUT_CODES_H

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -1,6 +1,6 @@
 /**
  *   MIT/X11 License
- *   Modified  (c) 2017 Morgane Glidic, (c) 2020-2025 lbonn
+ *   Modified  (c) 2017 Morgane Glidic, (c) 2020-2025 lbonn, (c) 2025 lvitals
  *
  *   Permission is hereby granted, free of charge, to any person obtaining
  *   a copy of this software and associated documentation files (the
@@ -29,7 +29,6 @@
 #include <config.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <linux/input-event-codes.h>
 #include <locale.h>
 #include <math.h>
 #include <stdint.h>
@@ -51,6 +50,7 @@
 
 #include <rofi.h>
 
+#include "input-codes.h"
 #include "keyb.h"
 #include "rofi-types.h"
 #include "settings.h"


### PR DESCRIPTION
Adds a new header to define BTN_LEFT/RIGHT/MIDDLE for cross-platform support. Simplifies display.c by removing Linux-specific checks.

> Please follow these steps before submitting your PR:
>
> - [x] This PR targets the `next` branch and not `master`
> - [x] If your PR is a work in progress, include [WIP] in its title
> - [x] Its commits' summaries are reasonably descriptive
> - [x] You've described what this PR addresses below
> - [x] You've included links to relevant issues, if any with `#issue_num`
> - [x] You've deleted this template
>
> Thank you for contributing to rofi! <3

Your description here...
