### PR TITLE
fix(drun): history not recorded for dbus-launched entries

### DIFF
--- a/source/modes/drun.c
+++ b/source/modes/drun.c
@@ -509,12 +509,13 @@ static void exec_cmd_entry(DRunModePrivateData *pd, DRunModeEntry *e,
     // terminal.
     gboolean terminal =
         g_key_file_get_boolean(e->key_file, e->action, "Terminal", NULL);
-    if (helper_execute_command(exec_path, fp, terminal, sn ? &context : NULL)) {
-      char *drun_cach_path = g_build_filename(cache_dir, DRUN_CACHE_FILE, NULL);
-      // Store it based on the unique identifiers (desktop_id).
-      history_set(drun_cach_path, e->desktop_id);
-      g_free(drun_cach_path);
-    }
+    launched = helper_execute_command(exec_path, fp, terminal, sn ? &context : NULL);
+  }
+  if (launched == TRUE) {
+    char *drun_cach_path = g_build_filename(cache_dir, DRUN_CACHE_FILE, NULL);
+    // Store it based on the unique identifiers (desktop_id).
+    history_set(drun_cach_path, e->desktop_id);
+    g_free(drun_cach_path);
   }
   g_free(wmclass);
   g_free(exec_path);


### PR DESCRIPTION
Closes #2111

Some applications are launched through dbus, e.g., Telegram:
```desktop
[Desktop Entry]
Name=Telegram
Comment=New era of messaging
TryExec=Telegram
Exec=Telegram -- %u
Icon=org.telegram.desktop
Terminal=false
StartupWMClass=TelegramDesktop
Type=Application
Categories=Chat;Network;InstantMessaging;Qt;
MimeType=x-scheme-handler/tg;x-scheme-handler/tonsite;
Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;
Actions=quit;
DBusActivatable=true
SingleMainWindow=true
X-GNOME-UsesNotifications=true
X-GNOME-SingleWindow=true

[Desktop Action quit]
Exec=Telegram -quit
Name=Quit Telegram
Icon=application-exit
```

If it's successfully launched, `rofi` should record it in `DRUN_CACHE_FILE`, but it's currently skipped:
https://github.com/davatorium/rofi/blob/efa98622a7358bc667a84beb8337daa5f99cc33c/source/modes/drun.c#L497-L518

This PR should fix this problem.