### PR TITLE
feat: support `text-input-unstable-v3`

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -88,6 +88,11 @@ Settings config = {
      *
      */
     .location = WL_CENTER,
+    /**
+     * On Wayland, specifies the layer where rofi is rendered. Available layers are
+     * `background`, `bottom`, `top`, `overlay`. The default layer is `overlay`.
+     */
+    .wayland_layer = "overlay",
     /** Y offset */
     .y_offset = 0,
     /** X offset */

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -180,6 +180,11 @@ Default:  Autodetect
 
 The X server to contact. Default is `$DISPLAY`.
 
+`-wayland-layer` *layer*
+
+On Wayland, specifies the layer where rofi is rendered. Available layers are
+`background`, `bottom`, `top`, `overlay`. The default layer is `overlay`.
+
 `-dmenu`
 
 Run **rofi** in dmenu mode. This allows for interactive scripts.

--- a/include/settings.h
+++ b/include/settings.h
@@ -104,6 +104,8 @@ typedef struct {
   /** Backend */
   DisplayBackend backend;
 
+  /** Wayland layer */
+  char *wayland_layer;
   /** Windows location/gravity */
   WindowLocation location;
   /** Y offset */

--- a/include/view.h
+++ b/include/view.h
@@ -30,6 +30,7 @@
 
 #include "mode.h"
 #include "widgets/widget.h"
+#include "widgets/textbox.h"
 #include <pango/pango.h>
 #ifdef ENABLE_XCB
 #include <xcb/xcb.h>
@@ -210,6 +211,13 @@ void rofi_view_free(RofiViewState *state);
  * @returns the active view handle or NULL
  */
 RofiViewState *rofi_view_get_active(void);
+
+/**
+  * Get the current active textbox with the user input.
+  *
+  * @returns the active textbox or NULL
+  */
+textbox *rofi_view_get_active_text(void);
 
 /**
  * @param state the new active view handle.

--- a/include/wayland-internal.h
+++ b/include/wayland-internal.h
@@ -85,6 +85,8 @@ typedef struct {
 
   uint32_t layer_width;
   uint32_t layer_height;
+
+  struct zwp_text_input_manager_v3 *text_input_manager;
 } wayland_stuff;
 
 struct _wayland_seat {
@@ -120,6 +122,8 @@ struct _wayland_seat {
     double vertical;
     double horizontal;
   } wheel_continuous;
+
+  struct zwp_text_input_v3 *text_input;
 };
 
 /* Supported interface versions */

--- a/meson.build
+++ b/meson.build
@@ -318,6 +318,7 @@ if wayland_enabled
         wayland_sys_protocols_dir + '/stable/xdg-shell/xdg-shell.xml',
         wayland_sys_protocols_dir + '/unstable/primary-selection/primary-selection-unstable-v1.xml',
         wayland_sys_protocols_dir + '/unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml',
+        wayland_sys_protocols_dir + '/unstable/text-input/text-input-unstable-v3.xml',
         'protocols/wlr-foreign-toplevel-management-unstable-v1.xml',
         'protocols/wlr-layer-shell-unstable-v1.xml',
     )

--- a/source/view.c
+++ b/source/view.c
@@ -298,6 +298,14 @@ void rofi_view_restart(RofiViewState *state) {
 
 RofiViewState *rofi_view_get_active(void) { return current_active_menu; }
 
+textbox *rofi_view_get_active_text(void) {
+  RofiViewState *state = rofi_view_get_active();
+  if (state) {
+    return state->text;
+  }
+  return NULL;
+}
+
 void rofi_view_remove_active(RofiViewState *state) {
   if (state == current_active_menu) {
     rofi_view_set_active(NULL);

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -66,6 +66,7 @@
 #include "keyboard-shortcuts-inhibit-unstable-v1-protocol.h"
 #include "primary-selection-unstable-v1-protocol.h"
 #include "wlr-layer-shell-unstable-v1-protocol.h"
+#include "text-input-unstable-v3-protocol.h"
 
 #define wayland_output_get_dpi(output, scale, dimension)                       \
   ((output)->current.physical_##dimension > 0 && (scale) > 0                   \
@@ -113,6 +114,8 @@ static gboolean wayland_display_late_setup(void);
 static wayland_stuff wayland_;
 wayland_stuff *wayland = &wayland_;
 static const cairo_user_data_key_t wayland_cairo_surface_user_data;
+
+static const struct zwp_text_input_v3_listener text_input_listener;
 
 static void wayland_buffer_cleanup(wayland_buffer_pool *self) {
   if (!self->to_free) {
@@ -1108,6 +1111,10 @@ static void wayland_pointer_release(wayland_seat *self) {
 }
 
 static void wayland_seat_release(wayland_seat *self) {
+  if (self->text_input) {
+    zwp_text_input_v3_destroy(self->text_input);
+    self->text_input = NULL;
+  }
   wayland_keyboard_release(self);
   wayland_pointer_release(self);
 
@@ -1126,6 +1133,12 @@ static void wayland_seat_capabilities(void *data, struct wl_seat *seat,
       (self->keyboard == NULL)) {
     self->keyboard = wl_seat_get_keyboard(self->seat);
     wl_keyboard_add_listener(self->keyboard, &wayland_keyboard_listener, self);
+    if (wayland->text_input_manager) {
+      self->text_input = zwp_text_input_manager_v3_get_text_input(
+          wayland->text_input_manager, seat);
+      zwp_text_input_v3_add_listener(self->text_input, &text_input_listener,
+                                     self);
+    }
   } else if ((!(capabilities & WL_SEAT_CAPABILITY_POINTER)) &&
              (self->keyboard != NULL)) {
     wayland_keyboard_release(self);
@@ -1169,6 +1182,74 @@ static void wayland_seat_name(void *data, struct wl_seat *seat,
 static const struct wl_seat_listener wayland_seat_listener = {
     .capabilities = wayland_seat_capabilities,
     .name = wayland_seat_name,
+};
+
+static void update_cursor_rectangle(struct zwp_text_input_v3 *text_input) {
+  textbox *tb = rofi_view_get_active_text();
+  if (tb == NULL) {
+    return;
+  }
+
+  widget *tb_widget = WIDGET(tb);
+  int x = widget_get_x_pos(tb_widget) + textbox_get_cursor_x_pos(tb);
+  int y = widget_get_y_pos(tb_widget);
+  int w = 1;
+  int h = widget_get_height(tb_widget);
+  zwp_text_input_v3_set_cursor_rectangle(text_input, x, y, w, h);
+}
+
+static void text_input_enter(void *data, struct zwp_text_input_v3 *text_input,
+                             struct wl_surface *surface) {
+  zwp_text_input_v3_enable(text_input);
+  zwp_text_input_v3_set_content_type(
+      text_input, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE,
+      ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NORMAL);
+  update_cursor_rectangle(text_input);
+  zwp_text_input_v3_commit(text_input);
+}
+static void text_input_leave(void *data, struct zwp_text_input_v3 *text_input,
+                             struct wl_surface *surface) {
+  zwp_text_input_v3_disable(text_input);
+  zwp_text_input_v3_commit(text_input);
+}
+
+static void text_input_preedit_string(void *data,
+                                      struct zwp_text_input_v3 *text_input,
+                                      const char *text, int32_t cursor_begin,
+                                      int32_t cursor_end) {
+  update_cursor_rectangle(text_input);
+  zwp_text_input_v3_commit(text_input);
+}
+
+static void text_input_commit_string(void *data,
+                                     struct zwp_text_input_v3 *text_input,
+                                     const char *text) {
+  if (text == NULL) {
+    return;
+  }
+
+  RofiViewState *state = rofi_view_get_active();
+  if (state) {
+    rofi_view_handle_text(state, text);
+  }
+}
+
+static void
+text_input_delete_surrounding_text(void *data,
+                                   struct zwp_text_input_v3 *text_input,
+                                   uint32_t before_length,
+                                   uint32_t after_length) {}
+
+static void text_input_done(void *data, struct zwp_text_input_v3 *text_input,
+                            uint32_t serial) {}
+
+static const struct zwp_text_input_v3_listener text_input_listener = {
+    .enter = text_input_enter,
+    .leave = text_input_leave,
+    .preedit_string = text_input_preedit_string,
+    .commit_string = text_input_commit_string,
+    .delete_surrounding_text = text_input_delete_surrounding_text,
+    .done = text_input_done,
 };
 
 static void wayland_output_release(wayland_output *self) {
@@ -1377,6 +1458,10 @@ static void wayland_registry_handle_global(void *data,
         registry, name, &wp_cursor_shape_manager_v1_interface, 1);
   }
 #endif
+  else if (strcmp(interface, zwp_text_input_manager_v3_interface.name) == 0) {
+    wayland->text_input_manager = wl_registry_bind(
+        registry, name, &zwp_text_input_manager_v3_interface, 1);
+  }
 }
 
 static void wayland_registry_handle_global_remove(void *data,

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -1696,9 +1696,22 @@ static gboolean wayland_display_late_setup(void) {
     wlo = output->output;
   }
   wayland->surface = wl_compositor_create_surface(wayland->compositor);
+
+  uint32_t layer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
+  if (strcmp(config.wayland_layer, "overlay") == 0) {
+    layer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
+  } else if (strcmp(config.wayland_layer, "top") == 0) {
+    layer = ZWLR_LAYER_SHELL_V1_LAYER_TOP;
+  } else if (strcmp(config.wayland_layer, "bottom") == 0) {
+    layer = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+  } else if (strcmp(config.wayland_layer, "background") == 0) {
+    layer = ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
+  } else {
+    layer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
+    g_warning("Unknown wayland layer: %s, using default overlay", config.wayland_layer);
+  }
   wayland->wlr_surface = zwlr_layer_shell_v1_get_layer_surface(
-      wayland->layer_shell, wayland->surface, wlo,
-      ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "rofi");
+      wayland->layer_shell, wayland->surface, wlo, layer, "rofi");
 
   // Set size zero and anchor on all corners to get the usable screen size
   // see https://github.com/swaywm/wlroots/pull/2422

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -97,6 +97,13 @@ static XrmOption xrmOptions[] = {
      NULL,
      "Location on screen",
      CONFIG_DEFAULT},
+    {xrm_String,
+     "wayland-layer",
+     {.str = &config.wayland_layer},
+     NULL,
+     "On Wayland, specifies the layer where rofi is rendered. "
+     "Available layers are background, bottom, top, overlay.",
+     CONFIG_DEFAULT},
     {xrm_SNumber,
      "yoffset",
      {.snum = &config.y_offset},


### PR DESCRIPTION
This PR implements the `text-input-unstable-v3 protocol` for the Rofi Wayland backend. This is the standard protocol for handling advanced text input, including Input Method Editors (IMEs) and virtual keyboards.

Currently, Rofi's Wayland support for complex text input (e.g., for Chinese, Japanese, and Korean) is limited. The `text-input-unstable-v3` protocol provides a modern and more robust mechanism for integrating with IMEs like `Fcitx5`.

Related issue: [[REQUEST] input method support for wayland](https://github.com/lbonn/rofi/issues/131)

This PR consists of two commits:
1. Protocol Support (`text-input-unstable-v3`).
2. A new configuration option `-layer` to specify rofi's Wayland layer.

The current & default Wayland layer is `overlay` ([[BUG] Rofi being drawn under fullscreen window](https://github.com/lbonn/rofi/issues/12)). This may prevent Rofi from being hidden by a full-screen window (though it's not reproduced on my side, with Hyprland), but it also hides the input method candidate list. Setting the layer to `top` solves the problem.

Notice: Pre-edit text rendering is not implemented. I want to keep the content of this PR as small as possible by avoiding changes to `textbox` (or related theme styles). Also, this feature seems not to be implemented on the Rofi X11 backend.