### PR TITLE
[Theme] add alpha override support to references and hex colors.

### DIFF
--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -484,6 +484,10 @@ some of CSS 4)
 
 - Format: `{named-color} [ / {PERCENTAGE} ]`
 
+- Format: `#{HEX} [ / {PERCENTAGE} ]`
+
+- Format: `@{color-reference} [ / {PERCENTAGE} ]`
+
 The white-space format proposed in CSS4 is also supported.
 
 The different values are:

--- a/include/rofi-types.h
+++ b/include/rofi-types.h
@@ -268,6 +268,8 @@ typedef union _PropertyValue {
   struct {
     /** Name */
     char *name;
+	/** Is modified link */
+	gboolean modified;
     /** Cached looked up ref */
     struct Property *ref;
     /** Property default */

--- a/include/theme.h
+++ b/include/theme.h
@@ -417,4 +417,7 @@ typedef guint (*disp_scale_func)(void);
  * depending on the display library
  */
 void rofi_theme_set_disp_scale_func(disp_scale_func func);
+
+void rofi_theme_resolve_modified_link(Property*);
+
 #endif

--- a/lexer/theme-parser.y
+++ b/lexer/theme-parser.y
@@ -570,6 +570,13 @@ t_property_element
         $$ = rofi_theme_property_create ( P_LINK );
         $$->value.link.name = $1;
     }
+ /** @color_reference / 0-100% */
+|   T_LINK T_FORWARD_SLASH t_property_color_value_unit {
+	$$ = rofi_theme_property_create ( P_COLOR );
+	$$->value.link.name = $1;
+	$$->value.color.alpha = $3;
+	$$->value.link.modified = TRUE;
+    }
 |   T_BOOLEAN {
         $$ = rofi_theme_property_create ( P_BOOLEAN );
         $$->value.b = $1;
@@ -999,8 +1006,10 @@ t_property_color
     $$.alpha = $8;
 }
 /** Hex colors parsed by lexer. */
-| T_COLOR {
+| T_COLOR t_property_color_opt_alpha_ws {
     $$ = $1;
+	if ($2 != 1.0)
+		$$.alpha = $2;
 }
 | T_COLOR_TRANSPARENT {
     $$.alpha = 0.0;
@@ -1008,7 +1017,7 @@ t_property_color
 }
 | T_COLOR_NAME t_property_color_opt_alpha_ws {
     $$ = $1;
-    $$.alpha  = $2;
+    $$.alpha = $2;
 }
 ;
 t_property_color_opt_alpha_c

--- a/source/theme.c
+++ b/source/theme.c
@@ -1592,6 +1592,18 @@ static void rofi_theme_parse_process_links_int(ThemeWidget *wid) {
           }
         }
       }
+      if (pv->type == P_COLOR && pv->value.link.modified == TRUE) {
+        if (pv->value.link.ref == NULL) {
+			rofi_theme_resolve_modified_link(pv);
+			if (pv->value.link.ref && pv->value.link.ref->type == P_COLOR) {
+				ThemeColor referenced_color = pv->value.link.ref->value.color;
+				referenced_color.alpha = pv->value.color.alpha;
+				pv->value.color = referenced_color;
+			} else {
+				g_debug("Reference in alpha overriding does not point to color.");
+			}
+        }
+      }
     }
   }
 }
@@ -1660,3 +1672,12 @@ gboolean rofi_theme_has_property(const widget *wid_in, const PropertyType type,
 }
 
 void rofi_theme_set_disp_scale_func(disp_scale_func func) { disp_scale = func; }
+
+void rofi_theme_resolve_modified_link(Property* p) {
+	g_info("Resolving modified link to %s", p->value.link.name);
+	Property* temp_link = rofi_theme_property_create(P_LINK);
+	temp_link->value.link.name = g_strdup(p->value.link.name);
+	rofi_theme_resolve_link_property(temp_link, 0);
+	p->value.link.ref = temp_link->value.link.ref;
+	rofi_theme_property_free(temp_link);
+}


### PR DESCRIPTION
this adds support for the syntax `@color / 50%;` and `#123456 / 50%` to override the alpha of a given color.
- extended grammar rules for `t_property_element` and `t_property_color`
- added `gboolean` member to link `union` to differentiate modified links from normal links
- added definition of `rofi_theme_resolve_modified_link()`
- added implementation of modified link resolving in `rofi_theme_parse_process_links_int()`

https://github.com/davatorium/rofi/discussions/2200