### PR TITLE
Unpin meson version in CI

### DIFF
--- a/.github/actions/meson/action.yml
+++ b/.github/actions/meson/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - id: pip
-      run: pip install git+https://github.com/mesonbuild/meson@e58b3adc7044980bbddca1ad9674ac7b0c5bac0a ninja
+      run: pip install meson ninja
       shell: bash
     - id: setup
       run: meson setup builddir -Dxcb=${{ inputs.xcb }} -Dwayland=${{ inputs.wayland }}


### PR DESCRIPTION
It started causing problems with recent python versions

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

when running test