### PR TITLE
[WIP] Fix opening files, as `xdg-open` fails for terminal programs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build*/
 /.cache/
 /.vscode/
+tags
 
 # I want to ignore log files
 *.log

--- a/include/helper.h
+++ b/include/helper.h
@@ -303,6 +303,8 @@ typedef struct {
   const gchar *command;
 } RofiHelperExecuteContext;
 
+void helper_launch_default(const char *filepath);
+
 /**
  * @param wd   The working directory.
  * @param args The arguments of the command to exec.

--- a/source/helper.c
+++ b/source/helper.c
@@ -54,6 +54,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <glib/gconvert.h>
+#include <gio/gdesktopappinfo.h>
+
 const char *const MatchingMethodStr[MM_NUM_MATCHERS] = {
     "Normal", "Regex", "Glob", "Fuzzy", "Prefix"};
 
@@ -1070,6 +1073,16 @@ gboolean helper_execute(const char *wd, char **args, const char *error_precmd,
   // Free the args list.
   g_strfreev(args);
   return retv;
+}
+
+void helper_launch_default(const char *filepath)
+{
+    GError *error = NULL;
+    char *uri = g_filename_to_uri(filepath, NULL, &error);
+    if (!g_app_info_launch_default_for_uri(uri, NULL, &error)) {
+        g_printerr("Failed to open directory: %s\n", error->message);
+        g_error_free(error);
+    }
 }
 
 gboolean helper_execute_command(const char *wd, const char *cmd,

--- a/source/modes/filebrowser.c
+++ b/source/modes/filebrowser.c
@@ -506,9 +506,11 @@ static ModeMode file_browser_mode_result(Mode *sw, int mretv, char **input,
           get_file_browser(sw);
           return RESET_DIALOG;
         }
-      } else if ((pd->array[selected_line].type == RFILE) ||
-                 (pd->array[selected_line].type == DIRECTORY &&
-                  special_command)) {
+      } else if (pd->array[selected_line].type == RFILE) {
+        char *filepath = pd->array[selected_line].path;
+        helper_launch_default(filepath);
+        return MODE_EXIT;
+      } else if (pd->array[selected_line].type == DIRECTORY && special_command) {
         char *d_esc = g_shell_quote(pd->array[selected_line].path);
         char *cmd = g_strdup_printf("%s %s", pd->command, d_esc);
         g_free(d_esc);


### PR DESCRIPTION
### The issue

When using `rofi -show filebrowser`, opening a file silently fails if the associated program is a terminal program. In my case, associating
```
text/plain=nvim.desktop
```
results in files not being open. A little digging revealed  `file_browser_mode_result` in `modes/filebrowser.c`, the `run_in_term` argument is always `FALSE`
```c
helper_execute_command(cdir, cmd, FALSE, NULL);
                                   ^
                                   gboolean run_in_term
```
If I manually set it to 1, the text file is opened in Vim as I would expect. But seeing if `run_in_term` should be set would require parsing the associated programs .desktop entry.

### Suggestion

I suggest that instead of `xdg-open`, the Gio function `launch_default_for_uri` is used for opening regular files in their associated programs (this PR).

### Possible problem

Rofi only uses its `rofi-sensible-terminal` script, while GLib has a somewhat weird way of handling terminal selection (see https://gitlab.gnome.org/GNOME/glib/-/issues/2293), which could maybe trip up some users. Because of this, I denoted the PR as WIP.