### PR TITLE
fixup! use 'match:namespace' instead of 'match:class' for layerrules

### DIFF
--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -1187,7 +1187,7 @@ For hyprland >= 0.53.0:
 ```
 layerrule {
     name = fix-rofi
-    match:class = rofi
+    match:namespace = rofi
     no_anim = true
  }
 


### PR DESCRIPTION
`layerrule` doesn't have `match:class`, so if you set `match:class=<anything>`, it will apply to all layers. Test this by adding `dim_around = true` and `match:class=rofi` -> all layers will be dim