### PR TITLE
wayland: implement click-to-exit support using fullscreen capture surface

### DIFF
--- a/include/view-internal.h
+++ b/include/view-internal.h
@@ -195,6 +195,9 @@ typedef struct _view_proxy {
   void (*get_size)(struct RofiViewState *state, gint *width, gint *height);
 
   void (*pool_refresh)(void);
+
+  void (*get_menu_rect)(int *x, int *y, int *w, int *h);
+
 } view_proxy;
 
 typedef struct {

--- a/include/view.h
+++ b/include/view.h
@@ -29,8 +29,8 @@
 #define ROFI_VIEW_H
 
 #include "mode.h"
-#include "widgets/widget.h"
 #include "widgets/textbox.h"
+#include "widgets/widget.h"
 #include <pango/pango.h>
 #ifdef ENABLE_XCB
 #include <xcb/xcb.h>
@@ -213,10 +213,10 @@ void rofi_view_free(RofiViewState *state);
 RofiViewState *rofi_view_get_active(void);
 
 /**
-  * Get the current active textbox with the user input.
-  *
-  * @returns the active textbox or NULL
-  */
+ * Get the current active textbox with the user input.
+ *
+ * @returns the active textbox or NULL
+ */
 textbox *rofi_view_get_active_text(void);
 
 /**
@@ -372,7 +372,10 @@ void rofi_view_ping_mouse(RofiViewState *state);
 void rofi_view_set_window_title(const char *title);
 void rofi_view_pool_refresh(void);
 
+void rofi_view_get_menu_rect(int *x, int *y, int *w, int *h);
+
 void rofi_view_set_cursor(RofiCursorType type);
+
 
 /**
  * Input history
@@ -407,6 +410,9 @@ void rofi_view_ellipsize_listview(RofiViewState *state,
  * main_window
  */
 gboolean rofi_set_im_window_pos(int new_x, int new_y);
+
+// Cancel the current view
+void rofi_view_cancel(RofiViewState *state);
 
 /**
  * @param wid to test.

--- a/source/view.c
+++ b/source/view.c
@@ -306,6 +306,15 @@ textbox *rofi_view_get_active_text(void) {
   return NULL;
 }
 
+void rofi_view_cancel(RofiViewState *state) {
+  if (state == NULL) {
+    return;
+  }
+
+  state->retv = MENU_CANCEL;
+  state->quit = TRUE;
+}
+
 void rofi_view_remove_active(RofiViewState *state) {
   if (state == current_active_menu) {
     rofi_view_set_active(NULL);
@@ -2192,3 +2201,7 @@ void rofi_view_get_size(RofiViewState *state, gint *width, gint *height) {
 void rofi_view_ping_mouse(RofiViewState *state) { proxy->ping_mouse(state); }
 
 void rofi_view_pool_refresh(void) { proxy->pool_refresh(); }
+
+void rofi_view_get_menu_rect(int *x, int *y, int *w, int *h) {
+  proxy->get_menu_rect(x, y, w, h);
+}

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -117,6 +117,8 @@ static const cairo_user_data_key_t wayland_cairo_surface_user_data;
 
 static const struct zwp_text_input_v3_listener text_input_listener;
 
+static const struct _view_proxy *wayland_display_view_proxy(void);
+
 static void wayland_buffer_cleanup(wayland_buffer_pool *self) {
   if (!self->to_free) {
     return;
@@ -583,8 +585,27 @@ static void wayland_pointer_send_events(wayland_seat *self) {
     return;
   }
 
+  int menu_x = 0, menu_y = 0, menu_w = 0, menu_h = 0;
+
+  gboolean capture = config.click_to_exit;
+
+  if (capture) {
+    rofi_view_get_menu_rect(&menu_x, &menu_y, &menu_w, &menu_h);
+    if (menu_w <= 0 || menu_h <= 0) {
+      capture = FALSE;
+    }
+  }
+
   if (self->motion.x > -1 || self->motion.y > -1) {
-    rofi_view_handle_mouse_motion(state, self->motion.x, self->motion.y,
+    int motion_x = self->motion.x;
+    int motion_y = self->motion.y;
+
+    if (capture) {
+      motion_x -= menu_x;
+      motion_y -= menu_y;
+    }
+
+    rofi_view_handle_mouse_motion(state, motion_x, motion_y,
                                   config.hover_select);
     self->motion.x = -1;
     self->motion.y = -1;
@@ -604,17 +625,42 @@ static void wayland_pointer_send_events(wayland_seat *self) {
   }
 
   if (self->button.button > 0) {
+    gboolean inside = TRUE;
+
+    if (capture) {
+      inside = self->button.x >= menu_x && self->button.x < menu_x + menu_w &&
+               self->button.y >= menu_y && self->button.y < menu_y + menu_h;
+    }
+
     if (self->button.pressed) {
-      rofi_view_handle_mouse_motion(state, self->button.x, self->button.y,
-                                    FALSE);
+      if (capture && !inside) {
+        rofi_view_cancel(state);
+
+        self->button.button = 0;
+        rofi_view_maybe_update(state);
+        return;
+      }
+
+      int button_x = self->button.x;
+      int button_y = self->button.y;
+
+      if (capture) {
+        button_x -= menu_x;
+        button_y -= menu_y;
+      }
+
+      rofi_view_handle_mouse_motion(state, button_x, button_y, FALSE);
       nk_bindings_seat_handle_button(wayland->bindings_seat, NULL, button,
                                      NK_BINDINGS_BUTTON_STATE_PRESS,
                                      self->button.time);
     } else {
-      nk_bindings_seat_handle_button(wayland->bindings_seat, NULL, button,
-                                     NK_BINDINGS_BUTTON_STATE_RELEASE,
-                                     self->button.time);
+      if (!capture || inside) {
+        nk_bindings_seat_handle_button(wayland->bindings_seat, NULL, button,
+                                       NK_BINDINGS_BUTTON_STATE_RELEASE,
+                                       self->button.time);
+      }
     }
+
     self->button.button = 0;
   }
 
@@ -1203,9 +1249,9 @@ static void update_cursor_rectangle(struct zwp_text_input_v3 *text_input) {
 static void text_input_enter(void *data, struct zwp_text_input_v3 *text_input,
                              struct wl_surface *surface) {
   zwp_text_input_v3_enable(text_input);
-  zwp_text_input_v3_set_content_type(
-      text_input, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE,
-      ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NORMAL);
+  zwp_text_input_v3_set_content_type(text_input,
+                                     ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE,
+                                     ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NORMAL);
   update_cursor_rectangle(text_input);
   zwp_text_input_v3_commit(text_input);
 }
@@ -1236,11 +1282,9 @@ static void text_input_commit_string(void *data,
   }
 }
 
-static void
-text_input_delete_surrounding_text(void *data,
-                                   struct zwp_text_input_v3 *text_input,
-                                   uint32_t before_length,
-                                   uint32_t after_length) {}
+static void text_input_delete_surrounding_text(
+    void *data, struct zwp_text_input_v3 *text_input, uint32_t before_length,
+    uint32_t after_length) {}
 
 static void text_input_done(void *data, struct zwp_text_input_v3 *text_input,
                             uint32_t serial) {}
@@ -1289,18 +1333,18 @@ static wayland_output *wayland_output_by_name(const char *name) {
 }
 double wayland_get_dpi_estimation(void) {
   double retv = -1.0;
-  if ( wayland == 0 ) {
+  if (wayland == 0) {
     return -1.0;
   }
   gsize noutputs = g_hash_table_size(wayland->outputs);
-  if ( noutputs == 1) {
+  if (noutputs == 1) {
     GHashTableIter iter;
     wayland_output *output;
     g_hash_table_iter_init(&iter, wayland->outputs);
     if (g_hash_table_iter_next(&iter, NULL, (gpointer *)&output)) {
       return wayland_output_get_dpi(output, output->current.scale, height);
     }
-  } else if (noutputs > 1 && config.monitor != NULL ) {
+  } else if (noutputs > 1 && config.monitor != NULL) {
     wayland_output *output = wayland_output_by_name(config.monitor);
     if (output != NULL) {
       return wayland_output_get_dpi(output, output->current.scale, height);
@@ -1710,7 +1754,8 @@ static gboolean wayland_display_late_setup(void) {
     layer = ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
   } else {
     layer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
-    g_warning("Unknown wayland layer: %s, using default overlay", config.wayland_layer);
+    g_warning("Unknown wayland layer: %s, using default overlay",
+              config.wayland_layer);
   }
   wayland->wlr_surface = zwlr_layer_shell_v1_get_layer_surface(
       wayland->layer_shell, wayland->surface, wlo, layer, "rofi");
@@ -1762,6 +1807,11 @@ gboolean display_get_surface_dimensions(int *width, int *height) {
   return FALSE;
 }
 
+/* Click-capture is limited to the current output. If the menu is larger than
+ * the monitor and visually overflows onto another output, the overflowed area
+ * will not be part of the capture surface and clicks there will not trigger
+ * click-to-exit.
+ */
 void display_set_surface_dimensions(int width, int height, int x_margin,
                                     int y_margin, int loc) {
 
@@ -1917,8 +1967,8 @@ static void wayland_get_clipboard_data(int cb_type, ClipboardCb callback,
   if (cb_type == CLIPBOARD_DEFAULT) {
     wl_data_offer_receive(clipboard->offer, "text/plain;charset=utf-8", fds[1]);
   } else {
-    zwp_primary_selection_offer_v1_receive(clipboard->offer, "text/plain;charset=utf-8",
-                                           fds[1]);
+    zwp_primary_selection_offer_v1_receive(clipboard->offer,
+                                           "text/plain;charset=utf-8", fds[1]);
   }
   close(fds[1]);
 

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -64,6 +64,7 @@
  */
 static void wayland_rofi_view_update(RofiViewState *state, gboolean qr);
 
+void process_result(RofiViewState *state);
 /**
  * Structure holding some state
  */
@@ -81,6 +82,16 @@ static struct {
 
   int monitor_width;
   int monitor_height;
+
+  int surface_width;
+  int surface_height;
+
+  int menu_width;
+  int menu_height;
+
+  int menu_x;
+  int menu_y;
+
 } WlState = {
     .flags = MENU_NORMAL,
     .idle_timeout = 0,
@@ -89,6 +100,15 @@ static struct {
     .fullscreen = FALSE,
     .monitor_width = 0,
     .monitor_height = 0,
+
+    .surface_width = 0,
+    .surface_height = 0,
+
+    .menu_width = 0,
+    .menu_height = 0,
+
+    .menu_x = 0,
+    .menu_y = 0,
 };
 
 static void wayland_rofi_view_get_current_monitor(int *width, int *height) {
@@ -139,16 +159,106 @@ static int rofi_get_offset_px(RofiViewState *state, RofiOrientation ori) {
   return distance_get_pixel(offset, ori);
 }
 
+static void window_update_size_normal(RofiViewState *state, int offset_x,
+                                      int offset_y) {
+  WlState.surface_width = state->width;
+  WlState.surface_height = state->height;
+  WlState.menu_x = 0;
+  WlState.menu_y = 0;
+
+  display_set_surface_dimensions(state->width, state->height, offset_x,
+                                 offset_y, rofi_get_location(state));
+}
+
+static void window_update_size_with_outside_click(RofiViewState *state,
+                                                  int offset_x, int offset_y) {
+  int screen_width = 0;
+  int screen_height = 0;
+  int loc = rofi_get_location(state);
+
+  wayland_rofi_view_get_current_monitor(&screen_width, &screen_height);
+
+  if (screen_width <= 0 || screen_height <= 0) {
+    screen_width = state->width;
+    screen_height = state->height;
+  }
+
+  WlState.surface_width = screen_width;
+  WlState.surface_height = screen_height;
+
+  switch (loc) {
+  case WL_NORTH_WEST:
+    WlState.menu_x = offset_x;
+    WlState.menu_y = offset_y;
+    break;
+  case WL_NORTH:
+    WlState.menu_x =
+        (WlState.surface_width - WlState.menu_width) / 2 + offset_x;
+    WlState.menu_y = offset_y;
+    break;
+  case WL_NORTH_EAST:
+    WlState.menu_x = WlState.surface_width - WlState.menu_width - offset_x;
+    WlState.menu_y = offset_y;
+    break;
+  case WL_EAST:
+    WlState.menu_x = WlState.surface_width - WlState.menu_width - offset_x;
+    WlState.menu_y =
+        (WlState.surface_height - WlState.menu_height) / 2 + offset_y;
+    break;
+  case WL_SOUTH_EAST:
+    WlState.menu_x = WlState.surface_width - WlState.menu_width - offset_x;
+    WlState.menu_y = WlState.surface_height - WlState.menu_height - offset_y;
+    break;
+  case WL_SOUTH:
+    WlState.menu_x =
+        (WlState.surface_width - WlState.menu_width) / 2 + offset_x;
+    WlState.menu_y = WlState.surface_height - WlState.menu_height - offset_y;
+    break;
+  case WL_SOUTH_WEST:
+    WlState.menu_x = offset_x;
+    WlState.menu_y = WlState.surface_height - WlState.menu_height - offset_y;
+    break;
+  case WL_WEST:
+    WlState.menu_x = offset_x;
+    WlState.menu_y =
+        (WlState.surface_height - WlState.menu_height) / 2 + offset_y;
+    break;
+  case WL_CENTER:
+  default:
+    WlState.menu_x =
+        (WlState.surface_width - WlState.menu_width) / 2 + offset_x;
+    WlState.menu_y =
+        (WlState.surface_height - WlState.menu_height) / 2 + offset_y;
+    break;
+  }
+
+  /* Click-capture is limited to the current output. If the menu is larger than
+   * the output and visually overflows onto another output, the overflowed area
+   * will not be part of the capture surface and clicks there will not trigger
+   * click-to-exit.
+   */
+  display_set_surface_dimensions(WlState.surface_width, WlState.surface_height,
+                                 0, 0, WL_NORTH_WEST);
+}
+
 static void wayland_rofi_view_window_update_size(RofiViewState *state) {
   if (state == NULL) {
     return;
   }
+
   int offset_x = rofi_get_offset_px(state, ROFI_ORIENTATION_HORIZONTAL);
   int offset_y = rofi_get_offset_px(state, ROFI_ORIENTATION_VERTICAL);
 
   widget_resize(WIDGET(state->main_window), state->width, state->height);
-  display_set_surface_dimensions(state->width, state->height, offset_x,
-                                 offset_y, rofi_get_location(state));
+
+  WlState.menu_width = state->width;
+  WlState.menu_height = state->height;
+
+  if (config.click_to_exit) {
+    window_update_size_with_outside_click(state, offset_x, offset_y);
+  } else {
+    window_update_size_normal(state, offset_x, offset_y);
+  }
   rofi_view_pool_refresh();
 }
 
@@ -211,15 +321,16 @@ static void wayland_rofi_view_queue_redraw(void) {
 }
 
 static void wayland___create_window(MenuFlags menu_flags) {
+
   input_history_initialize();
 
   TICK_N("create cairo surface");
-  // TODO should we update the drawable each time?
   PangoContext *p = pango_context_new();
   pango_context_set_font_map(p, pango_cairo_font_map_get_default());
   TICK_N("pango cairo font setup");
 
   WlState.flags = menu_flags;
+
   // Setup dpi
   PangoFontMap *font_map = pango_cairo_font_map_get_default();
   if (config.dpi > 1) {
@@ -305,18 +416,30 @@ static void wayland_rofi_view_update(RofiViewState *state, gboolean qr) {
   }
   g_debug("Redraw view");
   TICK();
-  if (state->pool == NULL) {
-    state->pool = display_buffer_pool_new(state->width, state->height);
+
+  int buffer_width = state->width;
+  int buffer_height = state->height;
+
+  if (config.click_to_exit) {
+    buffer_width = WlState.surface_width;
+    buffer_height = WlState.surface_height;
   }
+
+  if (state->pool == NULL) {
+    state->pool = display_buffer_pool_new(buffer_width, buffer_height);
+  }
+
   cairo_surface_t *surface = display_buffer_pool_get_next_buffer(state->pool);
   if (surface == NULL) {
     // no available buffer, bail out
     return;
   }
+
   cairo_t *d = cairo_create(surface);
   cairo_set_operator(d, CAIRO_OPERATOR_SOURCE);
+
   // Paint the background transparent.
-  cairo_set_source_rgba(d, 0, 0, 0, 0.0);
+  cairo_set_source_rgba(d, 0, 0, 0, 0);
   guint scale = display_scale();
   cairo_surface_set_device_scale(surface, scale, scale);
   cairo_paint(d);
@@ -324,6 +447,16 @@ static void wayland_rofi_view_update(RofiViewState *state, gboolean qr) {
 
   // Always paint as overlay over the background.
   cairo_set_operator(d, CAIRO_OPERATOR_OVER);
+
+  if (config.click_to_exit) {
+    g_debug("draw capture mode: surface=%dx%d menu=%dx%d pos=(%d,%d)",
+            WlState.surface_width, WlState.surface_height, WlState.menu_width,
+            WlState.menu_height, WlState.menu_x, WlState.menu_y);
+    cairo_translate(d, WlState.menu_x, WlState.menu_y);
+  } else {
+    g_debug("draw normal mode: surface=%dx%d", buffer_width, buffer_height);
+  }
+
   widget_draw(WIDGET(state->main_window), d);
 
   TICK_N("widgets");
@@ -334,13 +467,6 @@ static void wayland_rofi_view_update(RofiViewState *state, gboolean qr) {
     wayland_rofi_view_queue_redraw();
   }
 }
-
-/**
- * @param state The Menu Handle
- *
- * Check if a finalize function is set, and if sets executes it.
- */
-void process_result(RofiViewState *state);
 
 static void wayland_rofi_view_frame_callback(void) {
   if (WlState.repaint_source == 0) {
@@ -410,6 +536,17 @@ static void wayland_rofi_view_pool_refresh(void) {
   wayland_rofi_view_update(state, TRUE);
 }
 
+static void wayland_rofi_view_get_menu_rect(int *x, int *y, int *w, int *h) {
+  if (x)
+    *x = WlState.menu_x;
+  if (y)
+    *y = WlState.menu_y;
+  if (w)
+    *w = WlState.menu_width;
+  if (h)
+    *h = WlState.menu_height;
+}
+
 static view_proxy view_ = {
     .update = wayland_rofi_view_update,
     .temp_configure_notify = NULL,
@@ -437,6 +574,8 @@ static view_proxy view_ = {
     .get_size = wayland_rofi_view_get_size,
 
     .pool_refresh = wayland_rofi_view_pool_refresh,
+
+    .get_menu_rect = wayland_rofi_view_get_menu_rect,
 };
 
 const view_proxy *wayland_view_proxy = &view_;


### PR DESCRIPTION
This PR implements native click-to-exit support for rofi's Wayland backend.

On Wayland, rofi cannot receive pointer events outside its surface, so
click-to-exit does not work when the surface only matches the visible
menu size. This patch addresses that by using a fullscreen transparent
surface when click-to-exit is enabled.

The visible menu keeps its normal size and theme-driven placement
inside that fullscreen surface. Pointer events are compared against the
visible menu rectangle so inside clicks continue through the normal
widget path, while outside clicks cancel the active view.

When click-to-exit is disabled, existing Wayland behavior remains
unchanged.

Fixes #2158

Tested with:
- `rofi -dmenu -no-config -no-click-to-exit`
- `rofi -dmenu -no-config -click-to-exit`
- `rofi -show drun -no-click-to-exit`
- `rofi -show drun -click-to-exit`

Also tested with non-centered placement to verify that theme-driven
positioning is preserved in capture mode.

Tested on Hyprland and Sway with single and multi-monitor setups. Outside clicks close as expected, including clicking on another monitor.