### PR TITLE
Add setting to include directories in recursivebrowser

### DIFF
--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -840,6 +840,8 @@ configuration {
       filter-regex: "(.*cache.*|.*\.o)";
       /** command */
       command: "xdg-open";
+      /** show directories in results */
+      include-directories: false;
    }
 }
 ```

--- a/source/modes/recursivebrowser.c
+++ b/source/modes/recursivebrowser.c
@@ -95,6 +95,7 @@ typedef struct {
   gboolean loading;
   int pipefd2[2];
   GRegex *filter_regex;
+  gboolean include_directories;
 } FileBrowserModePrivateData;
 
 static void free_list(FileBrowserModePrivateData *pd) {
@@ -153,6 +154,11 @@ static void recursive_browser_mode_init_config(Mode *sw) {
     pd->command = g_strdup(p->value.s);
   } else {
     pd->command = g_strdup(DEFAULT_OPEN);
+  }
+
+  p = rofi_theme_find_property(wid, P_BOOLEAN, "include-directories", TRUE);
+  if (p != NULL && p->type == P_BOOLEAN) {
+    pd->include_directories = p->value.b;
   }
 
   if (found_error) {
@@ -219,34 +225,34 @@ static void scan_dir(FileBrowserModePrivateData *pd, GFile *path) {
           break;
         case DT_REG:
         case DT_DIR: {
-          FBFile *f = g_malloc0(sizeof(FBFile));
-          // Rofi expects utf-8, so lets convert the filename.
-          f->path = g_build_filename(cdir, rd->d_name, NULL);
-          f->name = g_filename_to_utf8(f->path, -1, NULL, NULL, NULL);
-          if (f->name == NULL) {
-            f->name = rofi_force_utf8(rd->d_name, -1);
-          }
-          if (f->name == NULL) {
-            f->name = g_strdup("n/a");
-          }
-          f->type = (rd->d_type == DT_DIR) ? DIRECTORY : RFILE;
-          f->icon_fetch_uid = 0;
-          f->icon_fetch_size = 0;
-          f->icon_fetch_scale = 0;
-          f->link = FALSE;
+          if (rd->d_type == DT_REG || pd->include_directories) {
+            FBFile *f = g_malloc0(sizeof(FBFile));
+            // Rofi expects utf-8, so lets convert the filename.
+            f->path = g_build_filename(cdir, rd->d_name, NULL);
+            f->name = g_filename_to_utf8(f->path, -1, NULL, NULL, NULL);
+            if (f->name == NULL) {
+              f->name = rofi_force_utf8(rd->d_name, -1);
+            }
+            if (f->name == NULL) {
+              f->name = g_strdup("n/a");
+            }
+            f->type = (rd->d_type == DT_DIR) ? DIRECTORY : RFILE;
+            f->icon_fetch_uid = 0;
+            f->icon_fetch_size = 0;
+            f->icon_fetch_scale = 0;
+            f->link = FALSE;
 
-          g_async_queue_push(pd->async_queue, f);
-          if (g_async_queue_length(pd->async_queue) > 10000) {
-            write(pd->pipefd2[1], "r", 1);
+            g_async_queue_push(pd->async_queue, f);
+            if (g_async_queue_length(pd->async_queue) > 10000) {
+              write(pd->pipefd2[1], "r", 1);
+            }
           }
-
           if (rd->d_type == DT_DIR) {
             char *d = g_build_filename(cdir, rd->d_name, NULL);
             GFile *dirp = g_file_new_for_path(d);
             g_queue_push_tail(dirs_to_scan, dirp);
             g_free(d);
           }
-
           break;
         }
         case DT_UNKNOWN:

--- a/source/modes/recursivebrowser.c
+++ b/source/modes/recursivebrowser.c
@@ -217,7 +217,8 @@ static void scan_dir(FileBrowserModePrivateData *pd, GFile *path) {
         case DT_SOCK:
         default:
           break;
-        case DT_REG: {
+        case DT_REG:
+        case DT_DIR: {
           FBFile *f = g_malloc0(sizeof(FBFile));
           // Rofi expects utf-8, so lets convert the filename.
           f->path = g_build_filename(cdir, rd->d_name, NULL);
@@ -238,13 +239,14 @@ static void scan_dir(FileBrowserModePrivateData *pd, GFile *path) {
           if (g_async_queue_length(pd->async_queue) > 10000) {
             write(pd->pipefd2[1], "r", 1);
           }
-          break;
-        }
-        case DT_DIR: {
-          char *d = g_build_filename(cdir, rd->d_name, NULL);
-          GFile *dirp = g_file_new_for_path(d);
-          g_queue_push_tail(dirs_to_scan, dirp);
-          g_free(d);
+
+          if (rd->d_type == DT_DIR) {
+            char *d = g_build_filename(cdir, rd->d_name, NULL);
+            GFile *dirp = g_file_new_for_path(d);
+            g_queue_push_tail(dirs_to_scan, dirp);
+            g_free(d);
+          }
+
           break;
         }
         case DT_UNKNOWN:
@@ -430,7 +432,7 @@ static ModeMode recursive_browser_mode_result(Mode *sw, int mretv,
     retv = (mretv & MENU_LOWER_MASK);
   } else if ((mretv & MENU_OK)) {
     if (selected_line < pd->array_length) {
-      if (pd->array[selected_line].type == RFILE) {
+      if (pd->array[selected_line].type == RFILE || pd->array[selected_line].type == DIRECTORY) {
         char *d_esc = g_shell_quote(pd->array[selected_line].path);
         char *cmd = g_strdup_printf("%s %s", pd->command, d_esc);
         g_free(d_esc);


### PR DESCRIPTION
I'd prefer to be able to open directories, not just files, from recursivebrowser. My use case is making a giant combi config that can open anything on the system, sort of like Spotlight on a Mac.

I wrote a patch for my own use and have been using it for several months. #2212 makes it look like there's interest in upstreaming the functionality.