### PR TITLE
combi: makes combi compatible with `mode_preprocess_input`

### DIFF
--- a/source/modes/combi.c
+++ b/source/modes/combi.c
@@ -300,8 +300,13 @@ static cairo_surface_t *combi_get_icon(const Mode *sw, unsigned int index,
 
 static char *combi_preprocess_input(Mode *sw, const char *input) {
   CombiModePrivateData *pd = mode_get_private_data(sw);
+  char *input_preprocessed = g_strdup(input);
   for (unsigned i = 0; i < pd->num_switchers; i++) {
     pd->switchers[i].disable = FALSE;
+    char *input_preprocessed_old = input_preprocessed;
+    input_preprocessed =
+        mode_preprocess_input(pd->switchers[i].mode, input_preprocessed);
+    g_free(input_preprocessed_old);
   }
   if (input != NULL && input[0] == '!') {
     // Implement strchrnul behaviour.

--- a/source/modes/combi.c
+++ b/source/modes/combi.c
@@ -332,7 +332,7 @@ static char *combi_preprocess_input(Mode *sw, const char *input) {
       return g_strdup(eob + 1);
     }
   }
-  return g_strdup(input);
+  return g_strdup(input_preprocessed);
 }
 
 Mode combi_mode = {.name = "combi",

--- a/source/modes/combi.c
+++ b/source/modes/combi.c
@@ -312,6 +312,7 @@ static char *combi_preprocess_input(Mode *sw, const char *input) {
     }
     ssize_t bang_len = g_utf8_pointer_to_offset(input, eob) - 1;
     if (bang_len > 0) {
+      char *stripped_input = g_strdup(eob + 1);
       for (unsigned i = 0; i < pd->num_switchers; i++) {
         const char *mode_name = mode_get_name(pd->switchers[i].mode);
         size_t mode_name_len = g_utf8_strlen(mode_name, -1);
@@ -319,12 +320,18 @@ static char *combi_preprocess_input(Mode *sw, const char *input) {
               utf8_strncmp(&input[1], mode_name, bang_len) == 0)) {
           // No match.
           pd->switchers[i].disable = TRUE;
+        } else {
+          char *old_stripped_input = stripped_input;
+          stripped_input =
+              mode_preprocess_input(pd->switchers[i].mode, stripped_input);
+          g_free(old_stripped_input);
         }
       }
-      if (eob[0] == '\0' || eob[1] == '\0') {
+      if (eob[0] == '\0' || stripped_input[0] == '\0') {
+        g_free(stripped_input);
         return NULL;
       }
-      return g_strdup(eob + 1);
+      return stripped_input;
     }
   }
   char *input_preprocessed = g_strdup(input);

--- a/source/modes/combi.c
+++ b/source/modes/combi.c
@@ -300,13 +300,8 @@ static cairo_surface_t *combi_get_icon(const Mode *sw, unsigned int index,
 
 static char *combi_preprocess_input(Mode *sw, const char *input) {
   CombiModePrivateData *pd = mode_get_private_data(sw);
-  char *input_preprocessed = g_strdup(input);
   for (unsigned i = 0; i < pd->num_switchers; i++) {
     pd->switchers[i].disable = FALSE;
-    char *input_preprocessed_old = input_preprocessed;
-    input_preprocessed =
-        mode_preprocess_input(pd->switchers[i].mode, input_preprocessed);
-    g_free(input_preprocessed_old);
   }
   if (input != NULL && input[0] == '!') {
     // Implement strchrnul behaviour.
@@ -331,6 +326,13 @@ static char *combi_preprocess_input(Mode *sw, const char *input) {
       }
       return g_strdup(eob + 1);
     }
+  }
+  char *input_preprocessed = g_strdup(input);
+  for (unsigned i = 0; i < pd->num_switchers; i++) {
+    char *input_preprocessed_old = input_preprocessed;
+    input_preprocessed =
+        mode_preprocess_input(pd->switchers[i].mode, input_preprocessed);
+    g_free(input_preprocessed_old);
   }
   return input_preprocessed;
 }

--- a/source/modes/combi.c
+++ b/source/modes/combi.c
@@ -332,7 +332,7 @@ static char *combi_preprocess_input(Mode *sw, const char *input) {
       return g_strdup(eob + 1);
     }
   }
-  return g_strdup(input_preprocessed);
+  return input_preprocessed;
 }
 
 Mode combi_mode = {.name = "combi",


### PR DESCRIPTION
This PR allows modes `mode_preprocess_input` functions to work in `combi` mode.

This solves #2143 and probably #1934 but I haven't tested it with this person script.

Would also fix [this popular plugin issue](https://github.com/svenstaro/rofi-calc/issues/33).