### PR TITLE
Additional feature support for WaylandWindow

### DIFF
--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -982,21 +982,25 @@ configuration {
 
 ### window
 
-Show a list of all the windows and allow switching between them. Pressing the
-`delete-entry` binding (`shift-delete`) will close the window. Pressing the
-`accept-custom` binding (`control-enter` or `shift-enter`) will run a command
-on the window. (See option `window-command` );
+Show a list of all the windows and allow switching between them.
+Pressing the `delete-entry` binding (`shift-delete`) will close the window.
+Pressing the `accept-alt` binding (`shift-enter`) will run a command on the
+window. (See option `window-command` );
 
-If there is no match, it will try to launch the input.
+If there is no match, or if `accept-custom` (`control-enter`) is pressed, it
+will try to launch the input.
 
 ### windowcd
 
+Same as the **window** mode, but lists only windows on the current desktop.
 Shows a list of the windows on the current desktop and allows switching between
-them. Pressing the `delete-entry` binding (`shift-delete`) will kill the
-window. Pressing the `accept-custom` binding (`control-enter` or `shift-enter`)
-will run a command on the window. (See option `window-command` );
+them.
+Pressing the `delete-entry` binding (`shift-delete`) will kill the window.
+Pressing the `accept-alt` binding (`shift-enter`) will run a command on the
+window. (See option `window-command` );
 
-If there is no match, it will try to launch the input.
+If there is no match, or if `accept-custom` (`control-enter`) is pressed, it
+will try to launch the input.
 
 ### run
 

--- a/source/modes/wayland-window.c
+++ b/source/modes/wayland-window.c
@@ -423,6 +423,12 @@ static ModeMode wayland_window_mode_result(Mode *sw, int mretv,
         (ForeignToplevelHandle *)g_list_nth_data(pd->toplevels, selected_line);
     foreign_toplevel_handle_close(toplevel);
     wl_display_flush(pd->wayland->display);
+    ThemeWidget *wid = rofi_config_find_widget(sw->name, NULL, TRUE);
+    Property *p =
+        rofi_theme_find_property(wid, P_BOOLEAN, "close-on-delete", TRUE);
+    if (p && p->type == P_BOOLEAN && p->value.b == FALSE) {
+        return RELOAD_DIALOG;
+    }
   }
 
   return retv;

--- a/source/modes/wayland-window.c
+++ b/source/modes/wayland-window.c
@@ -429,6 +429,28 @@ static ModeMode wayland_window_mode_result(Mode *sw, int mretv,
     if (p && p->type == P_BOOLEAN && p->value.b == FALSE) {
         return RELOAD_DIALOG;
     }
+
+  } else if ((mretv & MENU_CUSTOM_INPUT) && *input != NULL &&
+             *input[0] != '\0') {
+    GError *error = NULL;
+    gboolean run_in_term = ((mretv & MENU_CUSTOM_ACTION) == MENU_CUSTOM_ACTION);
+    gsize lf_cmd_size = 0;
+    gchar *lf_cmd = g_locale_from_utf8(*input, -1, NULL, &lf_cmd_size, &error);
+    if (error != NULL) {
+      g_warning("Failed to convert command to locale encoding: %s",
+                error->message);
+      g_error_free(error);
+      return RELOAD_DIALOG;
+    }
+
+    RofiHelperExecuteContext context = {.name = NULL};
+    if (!helper_execute_command(NULL, lf_cmd, run_in_term,
+                                run_in_term ? &context : NULL)) {
+      retv = RELOAD_DIALOG;
+    }
+    g_free(lf_cmd);
+  } else if (mretv & MENU_CUSTOM_COMMAND) {
+    retv = (mretv & MENU_LOWER_MASK);
   }
 
   return retv;


### PR DESCRIPTION
Adds additional feature support for `window` mode under Wayland, bringing it closer to feature parity with the X11 version. Key changes are:
- [X] Handles `accept-custom` by running the entered command
- [X] Respects the `window.close-on-delete` config setting
- [X] Fixes self-contradictory keybind documentation
- [x] ~~Fills in the `{window}` placeholder in `window-command` with something reasonable~~ See #2295

Still a work in progress with regard to that last point. I'm completely new to Wayland protocol interactions, and while I think I've got the gist of it from looking at the existing code that speaks `wlr-foreign-toplevel-management-unstable-v1`, I'll definitely have questions for someone with more experience here.