### PR TITLE
fix: sigbus with shm file

### DIFF
--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -179,10 +179,16 @@ wayland_buffer_pool *display_buffer_pool_new(gint width, gint height) {
   size = (size_t)stride * height;
   pool_size = size * wayland->buffer_count;
 
-  fd = memfd_create("rofi-wayland-surface", MFD_CLOEXEC);
+  gchar *shm_name = "/rofi-wayland-surface";
+  fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+  shm_unlink(shm_name);
   if (fd < 0) {
     g_warning("creating a buffer file for %zu B failed: %s", pool_size,
               g_strerror(errno));
+    return NULL;
+  }
+  if (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0) {
+    g_close(fd, NULL);
     return NULL;
   }
   if (ftruncate(fd, pool_size) < 0) {

--- a/source/wayland/display.c
+++ b/source/wayland/display.c
@@ -140,6 +140,7 @@ static void wayland_buffer_cleanup(wayland_buffer_pool *self) {
   }
 
   munmap(self->data, self->size);
+  g_free(self->buffers);
   g_free(self);
 }
 
@@ -178,18 +179,10 @@ wayland_buffer_pool *display_buffer_pool_new(gint width, gint height) {
   size = (size_t)stride * height;
   pool_size = size * wayland->buffer_count;
 
-  gchar filename[PATH_MAX];
-  g_snprintf(filename, PATH_MAX, "%s/rofi-wayland-surface",
-             g_get_user_runtime_dir());
-  fd = g_open(filename, O_CREAT | O_RDWR, 0);
-  g_unlink(filename);
+  fd = memfd_create("rofi-wayland-surface", MFD_CLOEXEC);
   if (fd < 0) {
     g_warning("creating a buffer file for %zu B failed: %s", pool_size,
               g_strerror(errno));
-    return NULL;
-  }
-  if (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0) {
-    g_close(fd, NULL);
     return NULL;
   }
   if (ftruncate(fd, pool_size) < 0) {


### PR DESCRIPTION
Replace the file-based SHM allocation (`g_open` + `g_unlink` + `fcntl`) with `memfd_create`.

The previous approach used a fixed filename ($XDG_RUNTIME_DIR/rofi-wayland-surface), which is vulnerable to concurrent instances sharing the same inode and potentially to tmpfs page-fault restrictions on hardened kernels — both of which can produce SIGBUS.

`memfd_create("rofi-wayland-surface", MFD_CLOEXEC)` creates an anonymous, kernel-private fd with no directory entry, avoiding both issues.

Also fixes a missing `g_free(self->buffers)` in `wayland_buffer_cleanup`.

This should fix #2252

**Environment:** aarch64, Mali 610 (panfrost), Linux 6.18 (armbian), Hyprland

**Observed:** SIGBUS on startup when rofi attempts to paint the first frame.

**Backtrace:**
```
#0  pixman_fill32 (bits=0xfffff6cb6000, ...)  ← inaccessible address
#4  fill_boxes (cairo-image-compositor.c:350)
#13 cairo_paint (cr=0xfffff7130380)
#14 wayland_rofi_view_update (view.c:322)
#16 wayland_rofi_view_repaint (view.c:115)
```

GDB confirms the surface data pointer is valid but the mapped memory is inaccessible:
```
(gdb) print dst->data
$3 = (unsigned char *) 0xfffff6cb6000 <error: Cannot access memory at address 0xfffff6cb6000>
```