### PR TITLE
fixing docs typo

### DIFF
--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -616,7 +616,7 @@ It supports the following operations:
 - `+`      : Add
 - `-`      : Subtract
 - `/`      : Divide
-- `-`      : Multiply
+- `*`      : Multiply
 - `modulo` : Modulo
 - `min`    : Minimum of lvalue or rvalue;
 - `max`    : Maximum of lvalue or rvalue;


### PR DESCRIPTION
Noticed a typo in theme documentation for `calc` function, changed `-` to `*`