### PR TITLE
Fix glib inclusion order

### DIFF
--- a/source/keyb.c
+++ b/source/keyb.c
@@ -24,8 +24,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  */
-#include "keyb.h"
 #include "config.h"
+#include "keyb.h"
 #include "rofi.h"
 #include "xrmoptions.h"
 #include <glib.h>

--- a/source/modes/recursivebrowser.c
+++ b/source/modes/recursivebrowser.c
@@ -25,9 +25,10 @@
  */
 #define G_LOG_DOMAIN "Modes.RecursiveBrowser"
 
+#include "config.h"
+
 #include "glib.h"
 
-#include "config.h"
 #include <errno.h>
 #include <gio/gio.h>
 #include <gmodule.h>


### PR DESCRIPTION
Solves the warnings about redefinition of GLIB_VERSION_MIN_REQUIRED and GLIB_VERSION_MAX_ALLOWED
