### PR TITLE
Fix null pointer deref and skip misformed entry

### DIFF
--- a/source/modes/ssh.c
+++ b/source/modes/ssh.c
@@ -205,7 +205,7 @@ static SshEntry *read_known_hosts_file(const char *path, SshEntry *retv,
           char *strend = strchr(start, ']');
           if (strend == NULL)
           {
-            // If strend is NULL, then the entry is malformd. So it should be
+            // If strend is NULL, then the entry is malformed. So it should be
             // skipped.
             start = strsep(&sep, ", ");
             continue;

--- a/source/modes/ssh.c
+++ b/source/modes/ssh.c
@@ -203,7 +203,15 @@ static SshEntry *read_known_hosts_file(const char *path, SshEntry *retv,
         if (start[0] == '[') {
           start++;
           char *strend = strchr(start, ']');
-          if (strend[1] == ':') {
+          if (strend == NULL)
+          {
+            // If strend is NULL, then the entry is malformd. So it should be
+            // skipped.
+            start = strsep(&sep, ", ");
+            continue;
+          }
+          if (strend[1] == ':')
+          {
             *strend = '\0';
             errno = 0;
             gchar *endptr = NULL;


### PR DESCRIPTION
## Description
I’ve notice a potential null pointer deref when parsing a misformed ssh config. 
In [ssh.c](https://github.com/davatorium/rofi/blob/next/source/modes/ssh.c#L205), when the SSH hostnames(IPv6) get parsed, the code uses strchr() to find “]”. If the input is malformed (it exists a "[" but no "]"), then strchr will return NULL and thus NULL gets derefd which results in a segfault. 

## Solution:
Add a NULL check after strchr(). If it is null, skip the entry and continue with the remaining entries. 
