### PR TITLE
Replace malloc and realloc with corresponding glibc function

### DIFF
--- a/source/modes/ssh.c
+++ b/source/modes/ssh.c
@@ -494,7 +494,7 @@ static SshEntry *get_ssh(SSHModePrivateData *pd, unsigned int *length) {
   path = g_build_filename(cache_dir, SSH_CACHE_FILE, NULL);
   char **h = history_get_list(path, length);
 
-  retv = malloc((*length) * sizeof(SshEntry));
+  retv = g_malloc0((*length) * sizeof(SshEntry));
   for (unsigned int i = 0; i < (*length); i++) {
     int port = 0;
     char **ssplit = g_strsplit(h[i], "\x1F", -1);

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -868,14 +868,14 @@ static gboolean startup(G_GNUC_UNUSED gpointer data) {
     if (g_strcmp0(msg, "-") == 0) {
       size_t index = 0, i = 0;
       size_t length = 1024;
-      msg = malloc(length * sizeof(char));
+      msg = g_malloc(length * sizeof(char));
       while ((i = fread(&msg[index], 1, 1024, stdin)) > 0) {
         index += i;
         length += i;
         if (length >= ROFI_MAX_DMENU_INPUT) {
           break;
         }
-        msg = realloc(msg, length * sizeof(char));
+        msg = g_realloc(msg, length * sizeof(char));
       }
 
       msg[index] = 0;


### PR DESCRIPTION
## Description
The entire codebase uses g_malloc and g_realloc, but [rofi.c](https://github.com/davatorium/rofi/blob/next/source/rofi.c#L871) and [ssh.c](https://github.com/davatorium/rofi/blob/next/source/modes/ssh.c#L505) do not.
g_malloc terminates the program on allocation failure. malloc does not.

Is there a particular reason why malloc is used here instead of g_malloc?
If malloc should be used here, a NULL check should be added. 

## Solution:
Replace malloc/realloc with g_malloc/g_realloc in rofi.c and malloc with g_malloc0 in ssh.c. 