### PR TITLE
Fix selected row not being restored across content reloads

### DIFF
--- a/include/view-internal.h
+++ b/include/view-internal.h
@@ -101,6 +101,9 @@ struct RofiViewState {
   int skip_absorb;
   /** The selected line (in the unfiltered list) */
   unsigned int selected_line;
+  /** Selection requested before the content it refers to was loaded, applied
+   * on the next reload. UINT32_MAX when there is none. */
+  unsigned int pending_selected_line;
   /** The previously selected line (in the unfiltered list) */
   unsigned int previous_line;
   /** The return state of the view */

--- a/source/view.c
+++ b/source/view.c
@@ -344,20 +344,38 @@ void rofi_view_set_active(RofiViewState *state) {
   rofi_view_queue_redraw();
 }
 
+/**
+ * @param state The current RofiViewState
+ * @param line The line (in the unfiltered list) to move the selection to
+ *
+ * Move the selection to `line`, if it is part of the loaded content.
+ *
+ * @returns TRUE when the line was found.
+ */
+static gboolean rofi_view_select_line(RofiViewState *state, unsigned int line) {
+  if (line == UINT32_MAX) {
+    return FALSE;
+  }
+  for (unsigned int i = 0; i < state->filtered_lines; i++) {
+    if (state->line_map[i] == line) {
+      listview_set_selected(state->list_view, i);
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
 void rofi_view_set_selected_line(RofiViewState *state,
                                  unsigned int selected_line) {
   state->selected_line = selected_line;
-  // Find the line.
-  unsigned int selected = 0;
-  for (unsigned int i = 0; ((state->selected_line)) < UINT32_MAX && !selected &&
-                           i < state->filtered_lines;
-       i++) {
-    if (state->line_map[i] == (state->selected_line)) {
-      selected = i;
-      break;
-    }
+  /* line_map only describes content the view has already loaded; a reload
+   * rebuilds it later, in rofi_view_refilter_real(). Record what cannot be
+   * resolved yet instead of falling back to row 0, which would show the wrong
+   * selection until that reload lands. */
+  state->pending_selected_line = selected_line;
+  if (rofi_view_select_line(state, selected_line)) {
+    state->pending_selected_line = UINT32_MAX;
   }
-  listview_set_selected(state->list_view, selected);
 #ifdef ENABLE_XCB
   if (config.backend == DISPLAY_XCB) {
     // Clear the window and force an expose event resulting in a redraw.
@@ -419,7 +437,10 @@ const char *rofi_view_get_user_input(const RofiViewState *state) {
  * @returns a new 0 initialized RofiViewState
  */
 static RofiViewState *__rofi_view_state_create(void) {
-  return g_malloc0(sizeof(RofiViewState));
+  RofiViewState *state = g_malloc0(sizeof(RofiViewState));
+  // 0 is a valid line, so the sentinel has to be set explicitly.
+  state->pending_selected_line = UINT32_MAX;
+  return state;
 }
 
 /**
@@ -784,9 +805,11 @@ static gboolean rofi_view_refilter_real(RofiViewState *state) {
   }
   GTimer *timer = g_timer_new();
   TICK_N("Filter start");
+  gboolean content_reloaded = FALSE;
   if (state->reload) {
     _rofi_view_reload_row(state);
     state->reload = FALSE;
+    content_reloaded = TRUE;
   }
   TICK_N("Filter reload rows");
   if (state->tokens) {
@@ -881,6 +904,18 @@ static gboolean rofi_view_refilter_real(RofiViewState *state) {
   }
   TICK_N("Filter matching done");
   listview_set_num_elements(state->list_view, state->filtered_lines);
+
+  /* line_map now describes the content this pass installed, so a selection
+   * requested before it existed can be resolved. Doing so before the
+   * rofi_view_update() below keeps the wrong row off the first frame. Only on
+   * the reload path: a plain refilter would consume the request and drop it. */
+  if (content_reloaded && state->pending_selected_line != UINT32_MAX) {
+    unsigned int pending = state->pending_selected_line;
+    state->pending_selected_line = UINT32_MAX;
+    if (rofi_view_select_line(state, pending)) {
+      state->selected_line = pending;
+    }
+  }
 
   if (state->tb_filtered_rows) {
     char *r = g_strdup_printf("%u", state->filtered_lines);


### PR DESCRIPTION
### What this fixes

When a mode reloads its entries and requests that a particular row be selected, rofi sometimes selects row 0 instead. The failure depends on the size of the list being replaced rather than the new one, so it appears arbitrary: after navigating from a 100-item list into a 5-row submenu and back, restoring index 4 works, while index 5, one past the end of the list being replaced, falls back to row 0.

`rofi_view_set_selected_line()` resolves the requested line against `state->line_map`, which describes the content the view currently has *loaded*. A mode producing new content plus a selection to go with it cannot satisfy that precondition: `rofi_view_reload()` only arms the backend's reload timer, and `line_map` is rebuilt later, in `rofi_view_refilter_real()`. So the lookup runs against the previous page, and when the requested index is not in it the loop falls through to `selected = 0`. `state->selected_line` still reports the requested line, leaving `rofi_view_get_selected_line()` and `listview_get_selected()` disagreeing.

Because failure depends on the requested index happening to be in range of the page still on screen, it presents as an arbitrary threshold rather than an ordering problem, which is most of why it took me so long to pin down, or I just have brain-rot :/

### Reproducing

Built-in script mode hits this. `script_mode_result()` bounds-checks `new-selection` against the *new* list length and then resolves it against the *old* `line_map` (`source/modes/script.c:431`):

```c
    rmpd->cmd_list = new_list;
    rmpd->cmd_list_length = new_length;
    if (keep_selection) {
      if (rmpd->new_selection >= 0 &&
          rmpd->new_selection < rmpd->cmd_list_length) {
        rofi_view_set_selected_line(rofi_view_get_active(),
                                    rmpd->new_selection);
```

Debug script and instructions: https://gist.github.com/vredesbyyrd/a8fe01a182f49e32987e1ea394e3359b

Two nested menus, 100 rows and 5 (the submenu's first row is `< Back`). Select row 5, then Back: the selection returns to row 5. Select row 6, then Back: the selection lands on row 0, that request is for index 5, resolved against the 5-row submenu still on screen. The boundary is the size of the list you navigate away from. Fails on both backends (wayland/x11); fixed by this PR.

### Where I hit it

[rofi-blocks](https://github.com/OmarCastro/rofi-blocks), writing a script with nested menus (artists → albums → tracks) that restores the row you came from on the way back up.

There it only ever manifested on wayland, which tracing eventually explained too. rofi-blocks carries a workaround that re-issues the selection from a 33 ms timeout ([OmarCastro/rofi-blocks@073b4c8](https://github.com/OmarCastro/rofi-blocks/commit/073b4c8), for [OmarCastro/rofi-blocks#31](https://github.com/OmarCastro/rofi-blocks/issues/31)). xcb arms its reload timer at 10 ms (`source/xcb/view.c:460`) and wayland at ~67 ms (`source/wayland/view.c:307`), so that retry lands after the line map has been rebuilt on xcb and before it on wayland. On xcb the first frame is still drawn with the wrong row and the retry corrects it a frame later, which is presumably why it never looked like a bug there, though it did occasionally read as a glitch.

### The change

- Add `state->pending_selected_line` to record a selection request `rofi_view_set_selected_line()` could not yet resolve.
- `rofi_view_refilter_real()` applies the pending request immediately after `listview_set_num_elements()` and before repainting, so the first frame with the new content already has the correct row selected. One step, no timer.
- Requests are one-shot and honoured only on the reload path. `state->selected_line` is deliberately stale between activations (plain listview navigation never writes it), so re-applying it on an ordinary filter refilter would move the selection out from under the user.
- The existing lookup loop is lifted into a static helper, `rofi_view_select_line()`, shared by both sites.
- When a request cannot be resolved, the selection is now left alone rather than falling back to row 0. `-selected-row` is unaffected: it runs after `rofi_view_create()` has already refiltered, with the selection still at 0. `rofi_view_clear_input()` is unaffected because both its call sites immediately force a reload through `rofi_view_switch_mode()`, which resolves the request in that same pass.
  

### Testing

`meson test` passes. I tested `drun`, `run`, `window`, `dmenu`, and `script` with filtering, page navigation, `-selected-row`, and mode switching on both backends against a stock build and observed no regressions.

### Related

With this in place the rofi-blocks workaround becomes unnecessary and can be dropped (https://github.com/vredesbyyrd/rofi-blocks/commit/17525c5).

That removal is only correct against a rofi carrying this fix; against an older rofi the behaviour is the pre-workaround one. I have not proposed it upstream to rofi-blocks yet, it seemed right to see how this lands first.

### Full Disclosure

I spent a considerable amount of time investigating and narrowing this down, unsuccessfully, before bringing in any llm assistance. I am not a `C` expert and I am not deeply familiar with rofi's code, so I used "AI" to help me understand the code paths involved and to implement the fix. Totally understand if you would prefer not to accept llm-assisted contributions. I'm filing it because the issue seemed worth reporting either way, and because I have been running the patch with rofi-blocks without hitting any regressions in my own testing. 