### PR TITLE
doc: fix minor spelling typos

### DIFF
--- a/doc/man_filter.lua
+++ b/doc/man_filter.lua
@@ -52,7 +52,7 @@ function find_defs(doc)
     local idx = 0
     local def = Def:new()
 
-    -- find defintions:
+    -- find definitions:
     -- * start at paragraphs with `word` ...
     -- * stop at next definition or next header
     local filter = {

--- a/doc/rofi-dmenu.5.markdown
+++ b/doc/rofi-dmenu.5.markdown
@@ -190,7 +190,7 @@ Set ellipsize mode to start. So, the end of the string is visible.
 
 `-display-columns`
 
-A comma seperated list of columns to show.
+A comma separated list of columns to show.
 
 `-display-column-separator`
 

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -1118,7 +1118,7 @@ The following properties are currently supported:
 
 - **reverse**:         boolean Reverse the ordering (top down to bottom up).
 
-- **flow**:           orientation The order the elements are layed out.
+- **flow**:           orientation The order the elements are laid out.
     Vertical is the original 'column' view.
 
 - **fixed-columns**:    boolean Do not reduce the number of columns shown when


### PR DESCRIPTION
Fixes a few small typos found while reading through the docs:

- `doc/man_filter.lua`: `defintions` -> `definitions`
- `doc/rofi-dmenu.5.markdown`: `seperated` -> `separated`
- `doc/rofi-theme.5.markdown`: `layed` -> `laid`

No functional changes.