### PR TITLE
Fix row icons and previews that fail to render

### DIFF
--- a/source/modes/dmenu.c
+++ b/source/modes/dmenu.c
@@ -726,8 +726,11 @@ static cairo_surface_t *dmenu_get_icon(const Mode *sw,
     return NULL;
   }
 
-  if (dr->icon_fetch_uid > 0) {
-    cairo_surface_t *surface = NULL;
+  /* A row icon and icon-current-entry ask for the same entry at different
+   * sizes; one cached uid cannot serve both. */
+  cairo_surface_t *surface = NULL;
+  if (dr->icon_fetch_uid > 0 && dr->icon_fetch_size == height &&
+      dr->icon_fetch_scale == scale) {
     gboolean query_done = rofi_icon_fetcher_get_ex(dr->icon_fetch_uid, &surface);
 
     if (surface != NULL) {
@@ -751,11 +754,13 @@ static cairo_surface_t *dmenu_get_icon(const Mode *sw,
     dr->icon_fetch_uid = rofi_icon_fetcher_query(current_icon, height);
     dr->icon_fetch_size = height;
     dr->icon_fetch_scale = scale;
-
-  } else {
-    dr->icon_fetch_uid = 0;
+    /* The sizes alternate, so returning NULL would blank the icon on every
+     * frame, not just the first. */
+    rofi_icon_fetcher_get_ex(dr->icon_fetch_uid, &surface);
+    return surface;
   }
 
+  dr->icon_fetch_uid = 0;
   return NULL;
 }
 

--- a/source/modes/script.c
+++ b/source/modes/script.c
@@ -291,6 +291,9 @@ static DmenuScriptEntry *execute_executor(Mode *sw, char *arg,
             retv[(*length)].icon_fetch_uid = 0;
             retv[(*length)].icon_fetch_size = 0;
             retv[(*length)].icon_fetch_scale = 0;
+            /* The memset below only clears the next slot, leaving the
+             * first entry uninitialized. */
+            retv[(*length)].icon_fallback_index = 0;
             retv[(*length)].nonselectable = FALSE;
             retv[(*length)].permanent = FALSE;
             if (buf_length > 0 && (read_length > (ssize_t)buf_length)) {

--- a/source/modes/script.c
+++ b/source/modes/script.c
@@ -567,8 +567,11 @@ static cairo_surface_t *script_get_icon(const Mode *sw,
     return NULL;
   }
 
-  if (dr->icon_fetch_uid > 0) {
-    cairo_surface_t *surface = NULL;
+  /* A row icon and icon-current-entry ask for the same entry at different
+   * sizes; one cached uid cannot serve both. */
+  cairo_surface_t *surface = NULL;
+  if (dr->icon_fetch_uid > 0 && dr->icon_fetch_size == height &&
+      dr->icon_fetch_scale == scale) {
     gboolean query_done =
         rofi_icon_fetcher_get_ex(dr->icon_fetch_uid, &surface);
 
@@ -593,11 +596,13 @@ static cairo_surface_t *script_get_icon(const Mode *sw,
     dr->icon_fetch_uid = rofi_icon_fetcher_query(current_icon, height);
     dr->icon_fetch_size = height;
     dr->icon_fetch_scale = scale;
-
-  } else {
-    dr->icon_fetch_uid = 0;
+    /* The sizes alternate, so returning NULL would blank the icon on every
+     * frame, not just the first. */
+    rofi_icon_fetcher_get_ex(dr->icon_fetch_uid, &surface);
+    return surface;
   }
 
+  dr->icon_fetch_uid = 0;
   return NULL;
 }
 

--- a/source/wayland/view.c
+++ b/source/wayland/view.c
@@ -284,6 +284,10 @@ static void wayland_rofi_view_ping_mouse(RofiViewState *state) { (void)state; }
 static gboolean wayland_rofi_view_reload_idle(G_GNUC_UNUSED gpointer data) {
   RofiViewState *state = rofi_view_get_active();
 
+  /* Clear before refiltering: a reload signalled during the pass, such as a
+   * finished icon fetch, would otherwise coalesce into it and be lost. */
+  WlState.idle_timeout = 0;
+
   if (state) {
     // For UI update on this.
     if (state->tb_total_rows) {
@@ -296,7 +300,6 @@ static gboolean wayland_rofi_view_reload_idle(G_GNUC_UNUSED gpointer data) {
 
     rofi_view_maybe_update(state);
   }
-  WlState.idle_timeout = 0;
   return G_SOURCE_REMOVE;
 }
 

--- a/source/xcb/view.c
+++ b/source/xcb/view.c
@@ -438,6 +438,10 @@ static void xcb_rofi_view_ping_mouse(RofiViewState *state) {
 static gboolean xcb_rofi_view_reload_idle(G_GNUC_UNUSED gpointer data) {
   RofiViewState *state = rofi_view_get_active();
 
+  /* Clear before redrawing: a reload signalled during the pass would
+   * otherwise coalesce into it and be lost. */
+  XcbState.idle_timeout = 0;
+
   if (state) {
     // For UI update on this.
     if (state->tb_total_rows) {
@@ -449,7 +453,6 @@ static gboolean xcb_rofi_view_reload_idle(G_GNUC_UNUSED gpointer data) {
     state->refilter = TRUE;
     xcb_rofi_view_queue_redraw();
   }
-  XcbState.idle_timeout = 0;
   return G_SOURCE_REMOVE;
 }
 


### PR DESCRIPTION
### What this fixes

Preview images (`icon-current-entry`) often fail to appear when the selection changes, and once one is missed it stays blank until you move the selection away and back. In `script` and `dmenu` the row icon goes missing with it; in `filebrowser` (and rofi-blocks) only the preview does.

### The bugs, and what changes

**1. Finished icon loads are thrown away.** Icons decode on a worker thread and signal the view with `rofi_view_reload()`. The reload handler cleared its "reload pending" flag only *after* refiltering, so a reload arriving mid-pass coalesced into the pass that had already read it, and was lost. Nothing asks again: the preview is refreshed only when the selection changes, while row icons recover on the next redraw, which is why `filebrowser` and rofi-blocks lose only the preview. Faster decodes fail more often, being likelier to land inside that window. *Fix: clear the flag first.*

**2. One cached icon id per entry, regardless of size.** A theme with both a row icon and a preview asks for one entry at two sizes, but `script` and `dmenu` cached a single id for it, so the second request got the first one's image. *Fix: match on size and scale, as `drun` already does.*

**3. The first entry's fallback index is uninitialized.** In `script`, the memset following each new entry clears the *next* slot, leaving entry 0 reading stale memory. An out-of-range value makes rofi skip the icon query, so the first row of every reloaded menu has no row icon and no preview. *Fix: set it explicitly, as `dmenu` already does.*

Only (1) can affect `filebrowser` or rofi-blocks; (2) and (3) touch `script.c` and `dmenu.c` alone.

### Reproducing

All three use the stock `fullscreen-preview.rasi`, which enables the preview when `PREVIEW=true` is set.

**Nested script mode**: the first row of each submenu gets no row icon and no preview. Test script and instructions: https://gist.github.com/vredesbyyrd/5dbb450335523f6b1ae6b7d193893435

**filebrowser**: open a directory with 100+ images and hold Page Down (more reliable than the arrow keys). Stop on an entry and the preview is often blank.

```sh
PREVIEW=true rofi -show filebrowser -theme fullscreen-preview.rasi
```

**dmenu**: page through quickly the same way. Here the row icon is missing as well as the preview.

```sh
find ~/path/to/images -maxdepth 1 -type f \( -iname '*.jpg' -o -iname '*.png' \) | sort |
  while IFS= read -r f; do printf '%s\0icon\x1f%s\n' "${f##*/}" "$f"; done |
  PREVIEW=true rofi -dmenu -show-icons -theme fullscreen-preview.rasi
```

I first hit this in [rofi-blocks](https://github.com/OmarCastro/rofi-blocks), which is what the video below shows before the fix.

https://github.com/user-attachments/assets/15302e49-9c9b-42a0-b442-e02dbd8165f4

### Testing

`meson test` passes. I have been running the branch daily with rofi-blocks, and checked `script`, `dmenu`, `filebrowser`, and `drun` with a preview theme on both backends (xcb/wayland) without hitting regressions.

### Full Disclosure

As stated in #2318, I am not a `C` expert and I am not deeply familiar with rofi's codebase, so I used AI to help me trace the relevant code paths and implement *parts* of this fix. All changes were carefully reviewed and tested, but additional eyes on are always appreciated.

P.S. I tried to keep the comments concise. I can remove them if preferred. 