### PR TITLE
Option to execute command instead of keybind for buttons

### DIFF
--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -1322,6 +1322,20 @@ icon-paste {
 }
 ```
 
+Alternatively, the property `exec` can be set to be a command such as a program or shell script instead of `action`. The optional property `exit-after-command` (default **false**) can be set so Rofi exits upon completion of that command.
+
+For example, the following configuration would create an icon widget that, when clicked, opens an XTerm session and closes Rofi:
+
+```css
+icon-xterm {
+    expand: false;
+    filename: "/usr/share/pixmaps/mini.xterm_48x48.xpm";
+    size: 24;
+    exec: "xterm";
+    exit-after-command: true;
+}
+```
+
 #### button
 
 This is a textbox widget that can have a 'clickable' action. The `action` can
@@ -1334,6 +1348,18 @@ button-paste {
     content: "My Clickable Message";
     vertical-align: 0.5;
     action: "kb-primary-paste";
+}
+```
+
+As with icon widgets, the button widget can alternatively be set to run a command when clicked with the `exec` property and Rofi can be set to exit upon the command's completion by setting the `exit-after-command` property to **true**.
+
+```css
+button-xterm {
+    expand: false;
+    content: "Launch XTerm";
+    vertical-align: 0.5;
+    exec: "xterm";
+    exit-after-command: true;
 }
 ```
 

--- a/source/view.c
+++ b/source/view.c
@@ -1552,6 +1552,9 @@ WidgetTriggerActionResult textbox_button_trigger_action(
   switch (action) {
   case MOUSE_CLICK_DOWN: {
     const char *type = rofi_theme_get_string(wid, "action", NULL);
+    const char *command = rofi_theme_get_string(wid, "exec", NULL);
+    const int exit_after = rofi_theme_get_boolean(wid, "exit-after-command", FALSE);
+
     if (type) {
       if (state->list_view) {
         (state->selected_line) =
@@ -1565,12 +1568,11 @@ WidgetTriggerActionResult textbox_button_trigger_action(
       }
       state->skip_absorb = TRUE;
       return WIDGET_TRIGGER_ACTION_RESULT_HANDLED;
-    } else {
-      const char *command = rofi_theme_get_string(wid, "exec", NULL);
-      const int exit_after = rofi_theme_get_boolean(wid, "exit-after-command", FALSE);
-      system(command);
-      if (exit_after) {
-	      rofi_quit_main_loop();
+    } else if (command) {
+      if (helper_execute_command(NULL, command, FALSE, NULL)) {
+        if (exit_after) {
+          rofi_quit_main_loop();
+        }
       }
     }
   }

--- a/source/view.c
+++ b/source/view.c
@@ -1565,6 +1565,13 @@ WidgetTriggerActionResult textbox_button_trigger_action(
       }
       state->skip_absorb = TRUE;
       return WIDGET_TRIGGER_ACTION_RESULT_HANDLED;
+    } else {
+      const char *command = rofi_theme_get_string(wid, "exec", NULL);
+      const int exit_after = rofi_theme_get_boolean(wid, "exit-after-command", FALSE);
+      system(command);
+      if (exit_after) {
+	      rofi_quit_main_loop();
+      }
     }
   }
   case MOUSE_CLICK_UP:
@@ -1790,7 +1797,8 @@ static void rofi_view_add_widget(RofiViewState *state, widget *parent_widget,
     icon *t = icon_create(parent_widget, name);
     /* small hack to make it clickable */
     const char *type = rofi_theme_get_string(WIDGET(t), "action", NULL);
-    if (type) {
+    const char *command = rofi_theme_get_string(WIDGET(t), "exec", NULL);
+    if (type || command) {
       WIDGET(t)->type = WIDGET_TYPE_EDITBOX;
     }
     box_add((box *)parent_widget, WIDGET(t), TRUE);


### PR DESCRIPTION
Currently, you can only have Rofi perform functions using buttons by setting them to perform a specific keybind, e.g. a button to paste the contents of the keyboard would have the `action` property set to `kb-primary-paste`. When clicked, it would perform the same function as the keybind it was set to.

In `dmenu` mode, custom keybinds (`kb-custom-X`) terminate Rofi and return a value when pressed, starting from 10. For example, when "ALT-1" (the default keybind for `kb-custom-1`) is pressed when in `dmenu`, a value of 10 is returned. This allows for the creation of scripts that execute commands on pressing these keybinds, e.g.

```bash
#!/bin/bash
rofi -dmenu
output=$?
if [[ $output -eq 10  ]]; then
  echo "Custom keybind 1"
elif [[ $output -eq 11 ]]; then
  echo "Custom keybind 2"
else 
  "Something else"
fi
```

In the above script, if you press ALT-1 you would get the output "Custom keybind 1", ALT-2 "Custom keybind 2", and any other keybind "Something else". You can map a button to a keybind using the `action` property and then make a script that executes a command on that keybind, and hence when the button is clicked that command will be run.

However, this does not seem to be the case in `drun` mode. When I press ALT-1 in `drun`, it just switches to `window` mode and ALT-2 takes me back to `drun` mode. This means those who want to add custom buttons to their `drun` menus, e.g. a lock button or a power off button, cannot do so.

My commit fixes this by adding a new string property for buttons, known as `exec`. If `action` is not set on a button, Rofi instead looks for the `exec` property which contains a command, such as a program or shell script. When the button is clicked, Rofi will run the command using stdlib's `system` function.

An optional boolean property (default set to `false`) `exit-after-command`, if `true`, will close Rofi upon the command's completion.

For example:

```
button-terminal {
	content: "Terminal";
	exec: "xterm &";
	exit-after-command: true;
}
```

When the button is clicked, xterm is launched in the background and Rofi will close.